### PR TITLE
Remove Any type restriction

### DIFF
--- a/katz/src/main/kotlin/katz/Either.kt
+++ b/katz/src/main/kotlin/katz/Either.kt
@@ -23,7 +23,7 @@ package katz
  * Represents a value of one of two possible types (a disjoint union.)
  * An instance of Either is either an instance of [Left] or [Right].
  */
-sealed class Either<out A : Any, out B : Any> {
+sealed class Either<out A, out B> {
 
     /**
      * Returns `true` if this is a [Right], `false` otherwise.
@@ -63,7 +63,7 @@ sealed class Either<out A : Any, out B : Any> {
      * @param fb the function to apply if this is a [Right]
      * @return the results of applying the function
      */
-    inline fun <C : Any> fold(fa: (A) -> C, fb: (B) -> C): C = when (this) {
+    inline fun <C> fold(fa: (A) -> C, fb: (B) -> C): C = when (this) {
         is Right -> fb(b)
         is Left -> fa(a)
     }
@@ -89,7 +89,7 @@ sealed class Either<out A : Any, out B : Any> {
      * Left(12).map { "flower" }  // Result: Left(12)
      * ```
      */
-    inline fun <C : Any> map(f: (B) -> C): Either<A, C> =
+    inline fun <C> map(f: (B) -> C): Either<A, C> =
             fold({ Left(it) }, { Right(f(it)) })
 
     /**
@@ -124,7 +124,7 @@ sealed class Either<out A : Any, out B : Any> {
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
-    data class Left<out A : Any>(val a: A) : Either<A, Nothing>() {
+    data class Left<out A>(val a: A) : Either<A, Nothing>() {
         override val isLeft = true
         override val isRight = false
     }
@@ -132,7 +132,7 @@ sealed class Either<out A : Any, out B : Any> {
     /**
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
-    data class Right<out B : Any>(val b: B) : Either<Nothing, B>() {
+    data class Right<out B>(val b: B) : Either<Nothing, B>() {
         override val isLeft = false
         override val isRight = true
     }
@@ -143,7 +143,7 @@ sealed class Either<out A : Any, out B : Any> {
  *
  * @param f The function to bind across [Either.Right].
  */
-inline fun <A : Any, B : Any, C : Any> Either<A, B>.flatMap(f: (B) -> Either<A, C>): Either<A, C> =
+inline fun <A, B, C> Either<A, B>.flatMap(f: (B) -> Either<A, C>): Either<A, C> =
         fold({ Either.Left(it) }, { f(it) })
 
 /**
@@ -155,7 +155,7 @@ inline fun <A : Any, B : Any, C : Any> Either<A, B>.flatMap(f: (B) -> Either<A, 
  * Left(12).getOrElse(17)  // Result: 17
  * ```
  */
-inline fun <B : Any> Either<*, B>.getOrElse(default: () -> B): B =
+inline fun <B> Either<*, B>.getOrElse(default: () -> B): B =
         fold({ default() }, { it })
 
 /**
@@ -174,7 +174,7 @@ inline fun <B : Any> Either<*, B>.getOrElse(default: () -> B): B =
  * left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * ```
  */
-inline fun <A : Any, B : Any> Either<A, B>.filterOrElse(predicate: (B) -> Boolean, default: () -> A): Either<A, B> =
+inline fun <A, B> Either<A, B>.filterOrElse(predicate: (B) -> Boolean, default: () -> A): Either<A, B> =
         fold({ Either.Left(it) }, { if (predicate(it)) Either.Right(it) else Either.Left(default()) })
 
 /**
@@ -191,5 +191,5 @@ inline fun <A : Any, B : Any> Either<A, B>.filterOrElse(predicate: (B) -> Boolea
  * @param elem    the element to test.
  * @return `true` if the option has an element that is equal (as determined by `==`) to `elem`, `false` otherwise.
  */
-fun <A : Any, B : Any> Either<A, B>.contains(elem: B): Boolean =
+fun <A, B> Either<A, B>.contains(elem: B): Boolean =
         fold({ false }, { it == elem })

--- a/katz/src/main/kotlin/katz/NonEmptyList.kt
+++ b/katz/src/main/kotlin/katz/NonEmptyList.kt
@@ -19,7 +19,7 @@ package katz
 /**
  * A List that can not be empty
  */
-class NonEmptyList<out A : Any> private constructor(
+class NonEmptyList<out A> private constructor(
         val head: A,
         val tail: List<A>,
         val all: List<A>) {
@@ -38,17 +38,17 @@ class NonEmptyList<out A : Any> private constructor(
 
     fun isEmpty(): Boolean = false
 
-    fun <B : Any> map(f: (A) -> B): NonEmptyList<B> =
+    fun <B> map(f: (A) -> B): NonEmptyList<B> =
             NonEmptyList(f(head), tail.map(f))
 
-    fun <B : Any> flatMap(f: (A) -> NonEmptyList<B>): NonEmptyList<B> =
+    fun <B> flatMap(f: (A) -> NonEmptyList<B>): NonEmptyList<B> =
             f(head) + tail.flatMap { f(it).all }
 
-    operator fun <A : Any> NonEmptyList<A>.plus(l: NonEmptyList<A>): NonEmptyList<A> = NonEmptyList(all + l.all)
+    operator fun <A> NonEmptyList<A>.plus(l: NonEmptyList<A>): NonEmptyList<A> = NonEmptyList(all + l.all)
 
-    operator fun <A : Any> NonEmptyList<A>.plus(l: List<A>): NonEmptyList<A> = NonEmptyList(all + l)
+    operator fun <A> NonEmptyList<A>.plus(l: List<A>): NonEmptyList<A> = NonEmptyList(all + l)
 
-    operator fun <A : Any> NonEmptyList<A>.plus(a: A): NonEmptyList<A> = NonEmptyList(all + a)
+    operator fun <A> NonEmptyList<A>.plus(a: A): NonEmptyList<A> = NonEmptyList(all + a)
 
     fun iterator(): Iterator<A> = all.iterator()
 
@@ -72,6 +72,6 @@ class NonEmptyList<out A : Any> private constructor(
     }
 
     companion object Factory {
-        fun <A : Any> of(head: A, vararg t: A): NonEmptyList<A> = NonEmptyList(head, t.asList())
+        fun <A> of(head: A, vararg t: A): NonEmptyList<A> = NonEmptyList(head, t.asList())
     }
 }

--- a/katz/src/main/kotlin/katz/Option.kt
+++ b/katz/src/main/kotlin/katz/Option.kt
@@ -22,13 +22,12 @@ package katz
  * Represents optional values. Instances of `Option`
  * are either an instance of $some or the object $none.
  */
-sealed class Option<out A: Any> {
+sealed class Option<out A> {
 
     companion object {
 
-        @Suppress("SENSELESS_COMPARISON")
-        inline fun <A: Any> fromNullable(f: () -> A): Option<A> = f().let { if (it == null) None else Some(it) }
-        operator fun <A : Any> invoke(a: A): Option<A> = Some(a)
+        inline fun <A> fromNullable(f: () -> A): Option<A> = f().let { if (it == null) None else Some(it) }
+        operator fun <A> invoke(a: A): Option<A> = Some(a)
     }
 
     /**
@@ -51,7 +50,7 @@ sealed class Option<out A: Any> {
      * @param  f   the function to apply
      * @see flatMap
      */
-    inline fun <B : Any> map(f: (A) -> B): Option<B> = fold({ None }, { a -> Some(f(a)) })
+    inline fun <B> map(f: (A) -> B): Option<B> = fold({ None }, { a -> Some(f(a)) })
 
     /**
      * Returns the result of applying $f to this $option's value if
@@ -63,7 +62,7 @@ sealed class Option<out A: Any> {
      * @param  f   the function to apply
      * @see map
      */
-    inline fun <B : Any> flatMap(f: (A) -> Option<B>): Option<B> = fold({ None }, { a -> f(a) })
+    inline fun <B> flatMap(f: (A) -> Option<B>): Option<B> = fold({ None }, { a -> f(a) })
 
     /**
      * Returns the result of applying $f to this $option's
@@ -75,7 +74,7 @@ sealed class Option<out A: Any> {
      * @param  ifEmpty the expression to evaluate if empty.
      * @param  f       the function to apply if nonempty.
      */
-    inline fun <B : Any> fold(ifEmpty: () -> B, f: (A) -> B): B = when (this) {
+    inline fun <B> fold(ifEmpty: () -> B, f: (A) -> B): B = when (this) {
         is None -> ifEmpty()
         is Some -> f(value)
     }
@@ -119,7 +118,7 @@ sealed class Option<out A: Any> {
      */
     inline fun forall(p: (A) -> Boolean): Boolean = exists(p)
 
-    data class Some<out A : Any>(val value: A) : Option<A>() {
+    data class Some<out A>(val value: A) : Option<A>() {
         override val isEmpty = false
     }
 
@@ -134,4 +133,4 @@ sealed class Option<out A: Any> {
  *
  * @param default  the default expression.
  */
-fun <B : Any> Option<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
+fun <B> Option<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })

--- a/katz/src/main/kotlin/katz/Try.kt
+++ b/katz/src/main/kotlin/katz/Try.kt
@@ -22,11 +22,11 @@ package katz
  *
  * Port of https://github.com/scala/scala/blob/v2.12.1/src/library/scala/util/Try.scala
  */
-sealed class Try<out A: Any> {
+sealed class Try<out A> {
 
     companion object {
 
-        inline operator fun <A: Any> invoke(f: () -> A): Try<A> =
+        inline operator fun <A> invoke(f: () -> A): Try<A> =
                 try { Success(f()) } catch (e: Throwable) { Failure(e) }
     }
 
@@ -43,12 +43,12 @@ sealed class Try<out A: Any> {
     /**
      * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
      */
-    inline fun <B: Any> flatMap(crossinline f: (A) -> Try<B>): Try<B> = fold({ Failure(it) }, { f(it) })
+    inline fun <B> flatMap(crossinline f: (A) -> Try<B>): Try<B> = fold({ Failure(it) }, { f(it) })
 
     /**
      * Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
      */
-    inline fun <B: Any> map(crossinline f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
+    inline fun <B> map(crossinline f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
 
     /**
      * Converts this to a `Failure` if the predicate is not satisfied.
@@ -72,7 +72,7 @@ sealed class Try<out A: Any> {
      * If `fb` is initially applied and throws an exception,
      * then `fa` is applied with this exception.
      */
-    fun <B: Any> fold(fa: (Throwable) -> B, fb: (A) -> B): B = when (this) {
+    fun <B> fold(fa: (Throwable) -> B, fb: (A) -> B): B = when (this) {
         is Failure -> fa(exception)
         is Success -> try { fb(value) } catch(e: Throwable) { fa(e) }
     }
@@ -80,7 +80,7 @@ sealed class Try<out A: Any> {
     /**
      * The `Failure` type represents a computation that result in an exception.
      */
-    class Failure<out A: Any>(val exception: Throwable) : Try<A>() {
+    class Failure<out A>(val exception: Throwable) : Try<A>() {
         override val isFailure: Boolean = false
         override val isSuccess: Boolean = true
     }
@@ -88,7 +88,7 @@ sealed class Try<out A: Any> {
     /**
      * The `Success` type represents a computation that return a successfully computed value.
      */
-    class Success<out A: Any>(val value: A) : Try<A>() {
+    class Success<out A>(val value: A) : Try<A>() {
         override val isFailure: Boolean = true
         override val isSuccess: Boolean = false
     }
@@ -99,22 +99,22 @@ sealed class Try<out A: Any> {
  *
  * ''Note:'': This will throw an exception if it is not a success and default throws an exception.
  */
-fun <B: Any> Try<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
+fun <B> Try<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
 
 /**
  * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
  * This is like `flatMap` for the exception.
  */
-fun <B: Any> Try<B>.recoverWith(f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { Try.Success(it) })
+fun <B> Try<B>.recoverWith(f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { Try.Success(it) })
 
 /**
  * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
  * This is like map for the exception.
  */
-fun <B: Any> Try<B>.recover(f: (Throwable) -> B): Try<B> = fold({ Try.Success(f(it)) }, { Try.Success(it) })
+fun <B> Try<B>.recover(f: (Throwable) -> B): Try<B> = fold({ Try.Success(f(it)) }, { Try.Success(it) })
 
 /**
  * Completes this `Try` by applying the function `f` to this if this is of type `Failure`,
  * or conversely, by applying `s` if this is a `Success`.
  */
-fun <B: Any> Try<B>.transform(s: (B) -> Try<B>, f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { flatMap(s) })
+fun <B> Try<B>.transform(s: (B) -> Try<B>, f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { flatMap(s) })


### PR DESCRIPTION
Before talk and discuss with @raulraja, we've concluded that this restriction has no sense. We can't more restrict that the language itself and moreover this restriction avoid models that we need like `fromNullable` in `Option`.

![giphy 2](https://cloud.githubusercontent.com/assets/2472301/24333800/0b602bfa-125f-11e7-87da-0d9a7a04da5a.gif)

