### PR TITLE
Create and use type alias for HK concrete clases and small fixes

### DIFF
--- a/katz/src/main/kotlin/katz/arrow/FunctionK.kt
+++ b/katz/src/main/kotlin/katz/arrow/FunctionK.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface FunctionK<F, G> {
+interface FunctionK<in F, out G> {
 
     /**
      * Applies this functor transformation from `F` to `G`

--- a/katz/src/main/kotlin/katz/data/Either.kt
+++ b/katz/src/main/kotlin/katz/data/Either.kt
@@ -16,13 +16,16 @@
 
 package katz
 
+typealias EitherKind<A, B> = HK2<Either.F, A, B>
+typealias EitherF<L> = HK<Either.F, L>
+
 /**
  * Port of https://github.com/scala/scala/blob/v2.12.1/src/library/scala/util/Either.scala
  *
  * Represents a value of one of two possible types (a disjoint union.)
  * An instance of Either is either an instance of [Left] or [Right].
  */
-sealed class Either<out A, out B> : HK2<Either.F, A, B> {
+sealed class Either<out A, out B> : EitherKind<A, B> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/Id.kt
+++ b/katz/src/main/kotlin/katz/data/Id.kt
@@ -16,7 +16,9 @@
 
 package katz
 
-data class Id<out A>(val value: A) : HK<Id.F, A> {
+typealias IdKind<A> = HK<Id.F, A>
+
+data class Id<out A>(val value: A) : IdKind<A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/Ior.kt
+++ b/katz/src/main/kotlin/katz/data/Ior.kt
@@ -20,6 +20,8 @@ import katz.Either.Left
 import katz.Either.Right
 import katz.Option
 
+typealias IorKind<A, B> = HK2<Ior.F, A, B>
+
 /**
  * Port of https://github.com/typelevel/cats/blob/v0.9.0/core/src/main/scala/cats/data/Ior.scala
  *
@@ -40,7 +42,7 @@ import katz.Option
  * The isomorphic Either form can be accessed via the [unwrap] method.
  */
 
-sealed class Ior<out A, out B> : HK2<Ior.F, A, B> {
+sealed class Ior<out A, out B> : IorKind<A, B> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/NonEmptyList.kt
+++ b/katz/src/main/kotlin/katz/data/NonEmptyList.kt
@@ -16,13 +16,15 @@
 
 package katz
 
+typealias NonEmptyListKind<A> = HK<NonEmptyList.F, A>
+
 /**
  * A List that can not be empty
  */
 class NonEmptyList<out A> private constructor(
         val head: A,
         val tail: List<A>,
-        val all: List<A>) : HK<NonEmptyList.F, A> {
+        val all: List<A>) : NonEmptyListKind<A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/Option.kt
+++ b/katz/src/main/kotlin/katz/data/Option.kt
@@ -16,13 +16,15 @@
 
 package katz
 
+typealias OptionKind<A> = HK<Option.F, A>
+
 /**
  * Port of https://github.com/scala/scala/blob/v2.12.1/src/library/scala/Option.scala
  *
  * Represents optional values. Instances of `Option`
  * are either an instance of $some or the object $none.
  */
-sealed class Option<out A> : HK<Option.F, A> {
+sealed class Option<out A> : OptionKind<A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -15,13 +15,16 @@
  */
 package katz
 
+typealias OptionTKind<F, A> = HK2<OptionT.F, F, A>
+typealias OptionTF<F> = HK<OptionT.F, F>
+
 /**
  * [OptionT]`<F, A>` is a light wrapper on an `F<`[Option]`<A>>` with some
  * convenient methods for working with this nested structure.
  *
  * It may also be said that [OptionT] is a monad transformer for [Option].
  */
-data class OptionT<F, A>(val value: HK<F, Option<A>>) : HK2<OptionT.F, F, A> {
+data class OptionT<F, A>(val value: HK<F, Option<A>>) : OptionTKind<F, A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -1,6 +1,8 @@
 package katz
 
-class Reader<D, A>(val k: Kleisli<Id.F, D, A>) {
+typealias ReaderKind<D, A> = Kleisli<Id.F, D, A>
+
+class Reader<D, A>(val k: ReaderKind<D, A>) {
 
     companion object Factory {
 

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -16,12 +16,12 @@
 
 package katz
 
-class CoproductComonad<F, G>(val FC : Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>> {
+class CoproductComonad<F, G>(val FC: Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>> {
 
-    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): CoproductKind<F, G, B> =
-        fa.ev().coflatMap(FC, GC, f)
+    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): Coproduct<F, G, B> =
+            fa.ev().coflatMap(FC, GC, f)
 
     override fun <A> extract(fa: CoproductKind<F, G, A>): A =
-        fa.ev().extract(FC, GC)
+            fa.ev().extract(FC, GC)
 
 }

--- a/katz/src/main/kotlin/katz/instances/EitherMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/EitherMonad.kt
@@ -16,13 +16,12 @@
 
 package katz
 
-class EitherMonad<L> : Monad<HK<Either.F, L>> {
+class EitherMonad<L> : Monad<EitherF<L>> {
     override fun <A> pure(a: A): Either<L, A> = Either.Right(a)
 
-    override fun <A, B> flatMap(fa: HK2<Either.F, L, A>, f: (A) -> HK2<Either.F, L, B>): Either<L, B> {
+    override fun <A, B> flatMap(fa: EitherKind<L, A>, f: (A) -> EitherKind<L, B>): Either<L, B> {
         return fa.ev().flatMap { f(it).ev() }
     }
-
 }
 
-fun <A, B> HK2<Either.F, A, B>.ev(): Either<A, B> = this as Either<A, B>
+fun <A, B> EitherKind<A, B>.ev(): Either<A, B> = this as Either<A, B>

--- a/katz/src/main/kotlin/katz/instances/IdMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IdMonad.kt
@@ -18,15 +18,15 @@ package katz
 
 object IdMonad : Monad<Id.F> {
 
-    override fun <A, B> map(fa: HK<Id.F, A>, f: (A) -> B): Id<B> =
+    override fun <A, B> map(fa: IdKind<A>, f: (A) -> B): Id<B> =
             fa.ev().map(f)
 
     override fun <A> pure(a: A): Id<A> = Id(a)
 
-    override fun <A, B> flatMap(fa: HK<Id.F, A>, f: (A) -> HK<Id.F, B>): Id<B> =
+    override fun <A, B> flatMap(fa: IdKind<A>, f: (A) -> IdKind<B>): Id<B> =
             fa.ev().flatMap { f(it).ev() }
 }
 
-fun <A> HK<Id.F, A>.ev(): Id<A> = this as Id<A>
+fun <A> IdKind<A>.ev(): Id<A> = this as Id<A>
 
-fun <A> HK<Id.F, A>.value(): A = this.ev().value
+fun <A> IdKind<A>.value(): A = this.ev().value

--- a/katz/src/main/kotlin/katz/instances/IorMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IorMonad.kt
@@ -17,11 +17,11 @@
 package katz
 
 class IorMonad<L>(val AA: Semigroup<L>) : Monad<HK<Ior.F, L>> {
-    override fun <A, B> flatMap(fa: HK<HK<Ior.F, L>, A>, f: (A) -> HK<HK<Ior.F, L>, B>): HK<HK<Ior.F, L>, B> =
+    override fun <A, B> flatMap(fa: IorKind<L, A>, f: (A) -> IorKind<L, B>): Ior<L, B> =
             fa.ev().flatMap(AA) { f(it).ev() }
 
-    override fun <A> pure(a: A): HK2<Ior.F, L, A> = Ior.Right(a)
+    override fun <A> pure(a: A): Ior<L, A> = Ior.Right(a)
 
 }
 
-fun <A, B> HK2<Ior.F, A, B>.ev(): Ior<A, B> = this as Ior<A, B>
+fun <A, B> IorKind<A, B>.ev(): Ior<A, B> = this as Ior<A, B>

--- a/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
@@ -18,14 +18,14 @@ package katz
 
 object NonEmptyListMonad : Monad<NonEmptyList.F> {
 
-    override fun <A, B> map(fa: HK<NonEmptyList.F, A>, f: (A) -> B): HK<NonEmptyList.F, B> =
+    override fun <A, B> map(fa: NonEmptyListKind<A>, f: (A) -> B): NonEmptyList<B> =
             fa.ev().map(f)
 
-    override fun <A> pure(a: A): HK<NonEmptyList.F, A> = NonEmptyList.of(a)
+    override fun <A> pure(a: A): NonEmptyList<A> = NonEmptyList.of(a)
 
-    override fun <A, B> flatMap(fa: HK<NonEmptyList.F, A>, f: (A) -> HK<NonEmptyList.F, B>): HK<NonEmptyList.F, B> =
+    override fun <A, B> flatMap(fa: NonEmptyListKind<A>, f: (A) -> NonEmptyListKind<B>): NonEmptyList<B> =
             fa.ev().flatMap { f(it).ev() }
 
 }
 
-fun <A> HK<NonEmptyList.F, A>.ev(): NonEmptyList<A> = this as NonEmptyList<A>
+fun <A> NonEmptyListKind<A>.ev(): NonEmptyList<A> = this as NonEmptyList<A>

--- a/katz/src/main/kotlin/katz/instances/OptionMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionMonad.kt
@@ -18,14 +18,14 @@ package katz
 
 object OptionMonad : Monad<Option.F> {
 
-    override fun <A, B> map(fa: HK<Option.F, A>, f: (A) -> B): Option<B> =
+    override fun <A, B> map(fa: OptionKind<A>, f: (A) -> B): Option<B> =
             fa.ev().map(f)
 
     override fun <A> pure(a: A): Option<A> = Option.Some(a)
 
-    override fun <A, B> flatMap(fa: HK<Option.F, A>, f: (A) -> HK<Option.F, B>): Option<B> =
+    override fun <A, B> flatMap(fa: OptionKind<A>, f: (A) -> OptionKind<B>): Option<B> =
             fa.ev().flatMap { f(it).ev() }
 
 }
 
-fun <A> HK<Option.F, A>.ev(): Option<A> = this as Option<A>
+fun <A> OptionKind<A>.ev(): Option<A> = this as Option<A>

--- a/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
@@ -16,14 +16,14 @@
 
 package katz
 
-class OptionTMonad<F>(val M: Monad<F>) : Monad<HK<OptionT.F, F>> {
+class OptionTMonad<F>(val M: Monad<F>) : Monad<OptionTF<F>> {
     override fun <A> pure(a: A): OptionT<F, A> = OptionT.pure(M, a)
 
-    override fun <A, B> flatMap(fa: HK<HK<OptionT.F, F>, A>, f: (A) -> HK<HK<OptionT.F, F>, B>): OptionT<F, B> =
+    override fun <A, B> flatMap(fa: OptionTKind<F, A>, f: (A) -> OptionTKind<F, B>): OptionT<F, B> =
             fa.ev().flatMap(M, { f(it).ev() })
 
-    override fun <A, B> map(fa: HK<HK<OptionT.F, F>, A>, f: (A) -> B): OptionT<F, B> =
+    override fun <A, B> map(fa: OptionTKind<F, A>, f: (A) -> B): OptionT<F, B> =
             fa.ev().map(M, f)
 }
 
-fun <F, A> HK2<OptionT.F, F, A>.ev(): OptionT<F, A> = this as OptionT<F, A>
+fun <F, A> OptionTKind<F, A>.ev(): OptionT<F, A> = this as OptionT<F, A>

--- a/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("UNUSED_PARAMETER")
+
 package katz
 
 interface Applicative<F> : Functor<F> {


### PR DESCRIPTION
Fix variance on FuntionK.
Suppress unused parameter Aplicative.kt due to dummyparamenter hack

Typealases created:
- EitherKind
- IdKind
- IorKind
- OptionKind

Also return concrete classes instead of HK counterpart on Monads