### PR TITLE
Global typeclass instances

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -20,8 +20,7 @@ complexity:
   LongMethod:
     threshold: 20
   LongParameterList:
-    active: true
-    threshold: 3
+    active: false
   LargeClass:
     threshold: 300
   ComplexMethod:
@@ -81,7 +80,7 @@ style:
   WildcardImport:
     active: true
   NamingConventionViolation:
-    active: true
+    active: false
 
 comments:
   active: true

--- a/katz/src/main/kotlin/katz/arrow/FunctionK.kt
+++ b/katz/src/main/kotlin/katz/arrow/FunctionK.kt
@@ -16,12 +16,18 @@
 
 package katz
 
-interface Functor<F> {
+interface FunctionK<F, G> {
 
-    fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
+    /**
+     * Applies this functor transformation from `F` to `G`
+     */
+    operator fun <A> invoke(fa: HK<F, A>): HK<G, A>
 
-    fun <A, B> lift(f: (A) -> B): (HK<F, A>) -> HK<F, B> =
-            { fa: HK<F, A> ->
-                map(fa, f)
-            }
 }
+
+fun <F, G, H> FunctionK<F, G>.or(h: FunctionK<H, G>): FunctionK<CoproductFG<F, H>, G> =
+        object : FunctionK<CoproductFG<F, H>, G> {
+            override fun <A> invoke(fa: CoproductKind<F, H, A>): HK<G, A> {
+                return fa.ev().fold(this@or, h)
+            }
+        }

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 The Katz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package katz
+
+typealias CoproductF<F> = HK<Coproduct.F, F>
+typealias CoproductFG<F, G> = HK<CoproductF<F>, G>
+typealias CoproductKind<F, G, A> = HK<CoproductFG<F, G>, A>
+
+fun <F, G, A> CoproductKind<F, G, A>.ev(): Coproduct<F, G, A> = this as Coproduct<F, G, A>
+
+data class Coproduct<F, G, A>(val run: Either<HK<F, A>, HK<G, A>>) : CoproductKind<F, G, A> {
+
+    class F private constructor()
+
+    companion object {
+
+        fun <F, G, A> leftc(x: HK<F, A>): Coproduct<F, G, A> =
+                Coproduct(Either.Left(x))
+
+        fun <F, G, A> rightc(x: HK<G, A>): Coproduct<F, G, A> =
+                Coproduct(Either.Right(x))
+
+    }
+
+    fun <B> map(F: Functor<F>, G: Functor<G>, f: (A) -> B): Coproduct<F, G, B> =
+            Coproduct(run.bimap(F.lift(f), G.lift(f)))
+
+    fun <B> coflatMap(F: Comonad<F>, G: Comonad<G>, f: (Coproduct<F, G, A>) -> B): Coproduct<F, G, B> =
+            Coproduct(run.bimap(
+                    { F.coflatMap(it, { f(Coproduct.leftc(it)) }) },
+                    { G.coflatMap(it, { f(Coproduct.rightc(it)) }) }
+            ))
+
+    fun extract(F: Comonad<F>, G: Comonad<G>): A =
+            run.fold({ F.extract(it) }, { G.extract(it) })
+
+    fun <H> fold(f: FunctionK<F, H>, g: FunctionK<G, H>): HK<H, A> =
+            run.fold({ f(it) }, { g(it) })
+
+}

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -43,7 +43,7 @@ data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: E
             run.fold({ f(it) }, { g(it) })
 
     companion object {
-        inline fun <reified F, reified G, A> invoke(CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>(), run: Either<HK<F, A>, HK<G, A>>) =
+        inline operator fun <reified F, reified G, A> invoke(CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>(), run: Either<HK<F, A>, HK<G, A>>) =
                 Coproduct(CF, CG, run)
     }
 

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -36,8 +36,9 @@ data class Coproduct<F, G, A>(val run: Either<HK<F, A>, HK<G, A>>) : CoproductKi
 
     }
 
-    fun <B> map(F: Functor<F>, G: Functor<G>, f: (A) -> B): Coproduct<F, G, B> =
-            Coproduct(run.bimap(F.lift(f), G.lift(f)))
+    fun <B> map(F: Functor<F>, G: Functor<G>, f: (A) -> B): Coproduct<F, G, B> {
+        return Coproduct(run.bimap(F.lift(f), G.lift(f)))
+    }
 
     fun <B> coflatMap(F: Comonad<F>, G: Comonad<G>, f: (Coproduct<F, G, A>) -> B): Coproduct<F, G, B> =
             Coproduct(run.bimap(

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -42,5 +42,10 @@ data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: E
     fun <H> fold(f: FunctionK<F, H>, g: FunctionK<G, H>): HK<H, A> =
             run.fold({ f(it) }, { g(it) })
 
+    companion object {
+        inline fun <reified F, reified G, A> invoke(CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>(), run: Either<HK<F, A>, HK<G, A>>) =
+                Coproduct(CF, CG, run)
+    }
+
 }
 

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -36,18 +36,18 @@ data class Coproduct<F, G, A>(val run: Either<HK<F, A>, HK<G, A>>) : CoproductKi
 
     }
 
-    fun <B> map(F: Functor<F>, G: Functor<G>, f: (A) -> B): Coproduct<F, G, B> {
-        return Coproduct(run.bimap(F.lift(f), G.lift(f)))
+    fun <B> map(f: (A) -> B): Coproduct<F, G, B> {
+        return Coproduct(run.bimap(instance<Functor<F>>().lift(f), instance<Functor<G>>().lift(f)))
     }
 
-    fun <B> coflatMap(F: Comonad<F>, G: Comonad<G>, f: (Coproduct<F, G, A>) -> B): Coproduct<F, G, B> =
+    fun <B> coflatMap(f: (Coproduct<F, G, A>) -> B): Coproduct<F, G, B> =
             Coproduct(run.bimap(
-                    { F.coflatMap(it, { f(Coproduct.leftc(it)) }) },
-                    { G.coflatMap(it, { f(Coproduct.rightc(it)) }) }
+                    { instance<Comonad<F>>().coflatMap(it, { f(Coproduct.leftc(it)) }) },
+                    { instance<Comonad<G>>().coflatMap(it, { f(Coproduct.rightc(it)) }) }
             ))
 
-    fun extract(F: Comonad<F>, G: Comonad<G>): A =
-            run.fold({ F.extract(it) }, { G.extract(it) })
+    fun extract(): A =
+            run.fold({ instance<Comonad<F>>().extract(it) }, { instance<Comonad<G>>().extract(it) })
 
     fun <H> fold(f: FunctionK<F, H>, g: FunctionK<G, H>): HK<H, A> =
             run.fold({ f(it) }, { g(it) })

--- a/katz/src/main/kotlin/katz/data/Either.kt
+++ b/katz/src/main/kotlin/katz/data/Either.kt
@@ -94,6 +94,12 @@ sealed class Either<out A, out B> : HK2<Either.F, A, B> {
             fold({ Left(it) }, { Right(f(it)) })
 
     /**
+     * Map over Left and Right of this Either
+     */
+    inline fun <C, D> bimap(fa: (A) -> C, fb: (B) -> D): Either<C, D> =
+            fold({ Left(fa(it)) }, { Right(fb(it)) })
+
+    /**
      * Returns `false` if [Left] or returns the result of the application of
      * the given predicate to the [Right] value.
      *

--- a/katz/src/main/kotlin/katz/data/Id.kt
+++ b/katz/src/main/kotlin/katz/data/Id.kt
@@ -26,5 +26,10 @@ data class Id<out A>(val value: A) : IdKind<A> {
 
     inline fun <B> flatMap(f: (A) -> Id<B>): Id<B> = f(value)
 
+    companion object : IdMonad, GlobalInstance<Monad<Id.F>>()
+
 }
 
+fun <A> IdKind<A>.ev(): Id<A> = this as Id<A>
+
+fun <A> IdKind<A>.value(): A = this.ev().value

--- a/katz/src/main/kotlin/katz/data/Ior.kt
+++ b/katz/src/main/kotlin/katz/data/Ior.kt
@@ -271,15 +271,15 @@ sealed class Ior<out A, out B> : IorKind<A, B> {
  *
  * @param f The function to bind across [Ior.Right].
  */
-inline fun <A, B, D> Ior<A, B>.flatMap(AA: Semigroup<A>, crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
+inline fun <A, B, D> Ior<A, B>.flatMap(crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
     is Ior.Left -> Ior.Left(value)
     is Ior.Right -> f(value)
     is Ior.Both -> {
         val fm = f(rightValue)
         when (fm) {
-            is Ior.Left -> Ior.Left(AA.combine(leftValue, fm.value))
+            is Ior.Left -> Ior.Left(instance<Semigroup<A>>().combine(leftValue, fm.value))
             is Ior.Right -> Ior.Right(fm.value)
-            is Ior.Both -> Ior.Both(AA.combine(leftValue, fm.leftValue), fm.rightValue)
+            is Ior.Both -> Ior.Both(instance<Semigroup<A>>().combine(leftValue, fm.leftValue), fm.rightValue)
         }
     }
 }

--- a/katz/src/main/kotlin/katz/data/Ior.kt
+++ b/katz/src/main/kotlin/katz/data/Ior.kt
@@ -271,7 +271,7 @@ sealed class Ior<out A, out B> : IorKind<A, B> {
  *
  * @param f The function to bind across [Ior.Right].
  */
-inline fun <A, B, D> Ior<A, B>.flatMap(SA : Semigroup<A>, crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
+inline fun <A, B, D> Ior<A, B>.flatMap(SA: Semigroup<A>, crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
     is Ior.Left -> Ior.Left(value)
     is Ior.Right -> f(value)
     is Ior.Both -> {

--- a/katz/src/main/kotlin/katz/data/Ior.kt
+++ b/katz/src/main/kotlin/katz/data/Ior.kt
@@ -271,15 +271,15 @@ sealed class Ior<out A, out B> : IorKind<A, B> {
  *
  * @param f The function to bind across [Ior.Right].
  */
-inline fun <A, B, D> Ior<A, B>.flatMap(crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
+inline fun <A, B, D> Ior<A, B>.flatMap(SA : Semigroup<A>, crossinline f: (B) -> Ior<A, D>): Ior<A, D> = when (this) {
     is Ior.Left -> Ior.Left(value)
     is Ior.Right -> f(value)
     is Ior.Both -> {
         val fm = f(rightValue)
         when (fm) {
-            is Ior.Left -> Ior.Left(instance<Semigroup<A>>().combine(leftValue, fm.value))
+            is Ior.Left -> Ior.Left(SA.combine(leftValue, fm.value))
             is Ior.Right -> Ior.Right(fm.value)
-            is Ior.Both -> Ior.Both(instance<Semigroup<A>>().combine(leftValue, fm.leftValue), fm.rightValue)
+            is Ior.Both -> Ior.Both(SA.combine(leftValue, fm.leftValue), fm.rightValue)
         }
     }
 }

--- a/katz/src/main/kotlin/katz/data/NonEmptyList.kt
+++ b/katz/src/main/kotlin/katz/data/NonEmptyList.kt
@@ -75,7 +75,7 @@ class NonEmptyList<out A> private constructor(
         return "NonEmptyList(all=$all)"
     }
 
-    companion object Factory {
+    companion object : NonEmptyListMonad, GlobalInstance<Monad<NonEmptyList.F>>() {
         fun <A> of(head: A, vararg t: A): NonEmptyList<A> = NonEmptyList(head, t.asList())
     }
 }

--- a/katz/src/main/kotlin/katz/data/Option.kt
+++ b/katz/src/main/kotlin/katz/data/Option.kt
@@ -28,7 +28,7 @@ sealed class Option<out A> : OptionKind<A> {
 
     class F private constructor()
 
-    companion object {
+    companion object : OptionMonad, GlobalInstance<Monad<Option.F>>() {
         inline fun <reified A : Any> fromNullable(a: A?): Option<A> = if (a != null) Option.Some(a) else Option.None
         operator fun <A> invoke(a: A): Option<A> = Option.Some(a)
     }

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -30,6 +30,8 @@ data class OptionT<F, A>(val MF : Monad<F>, val value: HK<F, Option<A>>) : Optio
 
     companion object {
 
+        inline operator fun <reified F, A> invoke(value: HK<F, Option<A>>, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, value)
+
         inline fun <reified F, A> pure(a: A, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(Option.Some(a)))
 
         inline fun <reified F> none(MF : Monad<F> = monad<F>()): OptionT<F, Nothing> = OptionT(MF, MF.pure(Option.None))
@@ -89,4 +91,3 @@ data class OptionT<F, A>(val MF : Monad<F>, val value: HK<F, Option<A>>) : Optio
 }
 
 
-inline fun <reified F, A> optionT(value: HK<F, Option<A>>, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, value)

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -29,60 +29,60 @@ data class OptionT<F, A>(val value: HK<F, Option<A>>) : OptionTKind<F, A> {
     class F private constructor()
 
     companion object {
-        fun <M, A> pure(F: Monad<M>, a: A): OptionT<M, A> = OptionT(F.pure(Option.Some(a)))
+        fun <M, A> pure(a: A): OptionT<M, A> = OptionT(instance<Applicative<M>>().pure(Option.Some(a)))
 
-        fun <M> none(F: Monad<M>): OptionT<M, Nothing> = OptionT(F.pure(Option.None))
+        fun <M> none(): OptionT<M, Nothing> = OptionT(instance<Applicative<M>>().pure(Option.None))
 
-        fun <M, A> fromOption(F: Monad<M>, value: Option<A>): OptionT<M, A> = OptionT(F.pure(value))
+        fun <M, A> fromOption(value: Option<A>): OptionT<M, A> = OptionT(instance<Applicative<M>>().pure(value))
     }
 
-    inline fun <B> fold(F: Functor<F>, crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
-            F.map(value, { option -> option.fold({ default() }, { f(it) }) })
+    inline fun <B> fold(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
+            instance<Functor<F>>().map(value, { option -> option.fold({ default() }, { f(it) }) })
 
     inline fun <B> cata(F: Functor<F>, crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
-            fold(F, { default() }, { f(it) })
+            fold({ default() }, { f(it) })
 
-    inline fun <B> flatMap(F: Monad<F>, crossinline f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF(F, { it -> f(it).value })
+    inline fun <B> flatMap(crossinline f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF({ it -> f(it).value })
 
-    inline fun <B> flatMapF(F: Monad<F>, crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> =
-            OptionT(F.flatMap(value, { option -> option.fold({ F.pure(Option.None) }, { f(it) }) }))
+    inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> =
+            OptionT(instance<Monad<F>>().flatMap(value, { option -> option.fold({ instance<Applicative<F>>().pure(Option.None) }, { f(it) }) }))
 
-    fun <B> liftF(F: Functor<F>, fa: HK<F, B>): OptionT<F, B> = OptionT(F.map(fa, { Option.Some(it) }))
+    fun <B> liftF(fa: HK<F, B>): OptionT<F, B> = OptionT(instance<Functor<F>>().map(fa, { Option.Some(it) }))
 
-    inline fun <B> semiflatMap(F: Monad<F>, crossinline f: (A) -> HK<F, B>): OptionT<F, B> =
-            flatMap(F, { option -> liftF(F, f(option)) })
+    inline fun <B> semiflatMap(crossinline f: (A) -> HK<F, B>): OptionT<F, B> =
+            flatMap({ option -> liftF(f(option)) })
 
-    inline fun <B> map(F: Functor<F>, crossinline f: (A) -> B): OptionT<F, B> =
-            OptionT(F.map(value, { it.map(f) }))
+    inline fun <B> map(crossinline f: (A) -> B): OptionT<F, B> =
+            OptionT(instance<Functor<F>>().map(value, { it.map(f) }))
 
-    fun getOrElse(F: Functor<F>, default: () -> A): HK<F, A> = F.map(value, { it.getOrElse(default) })
+    fun getOrElse(default: () -> A): HK<F, A> = instance<Functor<F>>().map(value, { it.getOrElse(default) })
 
-    inline fun getOrElseF(F: Monad<F>, crossinline default: () -> HK<F, A>): HK<F, A> = F.flatMap(value, { it.fold(default, { F.pure(it) }) })
+    inline fun getOrElseF(crossinline default: () -> HK<F, A>): HK<F, A> = instance<Monad<F>>().flatMap(value, { it.fold(default, { instance<Applicative<F>>().pure(it) }) })
 
-    inline fun filter(F: Functor<F>, crossinline p: (A) -> Boolean): OptionT<F, A> = OptionT(F.map(value, { it.filter(p) }))
+    inline fun filter(crossinline p: (A) -> Boolean): OptionT<F, A> = OptionT(instance<Functor<F>>().map(value, { it.filter(p) }))
 
-    inline fun forall(F: Functor<F>, crossinline p: (A) -> Boolean): HK<F, Boolean> = F.map(value, { it.forall(p) })
+    inline fun forall(crossinline p: (A) -> Boolean): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.forall(p) })
 
-    fun isDefined(F: Functor<F>): HK<F, Boolean> = F.map(value, { it.isDefined })
+    fun isDefined(): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.isDefined })
 
-    fun isEmpty(F: Functor<F>): HK<F, Boolean> = F.map(value, { it.isEmpty })
+    fun isEmpty(): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.isEmpty })
 
-    inline fun orElse(F: Monad<F>, crossinline default: () -> OptionT<F, A>): OptionT<F, A> =
-            orElseF(F, { default().value })
+    inline fun orElse(crossinline default: () -> OptionT<F, A>): OptionT<F, A> =
+            orElseF({ default().value })
 
-    inline fun orElseF(F: Monad<F>, crossinline default: () -> HK<F, Option<A>>): OptionT<F, A> =
-            OptionT(F.flatMap(value) {
+    inline fun orElseF(crossinline default: () -> HK<F, Option<A>>): OptionT<F, A> =
+            OptionT(instance<Monad<F>>().flatMap(value) {
                 when (it) {
-                    is Option.Some<A> -> F.pure(it)
+                    is Option.Some<A> -> instance<Applicative<F>>().pure(it)
                     is Option.None -> default()
                 }
             })
 
-    inline fun <B> transform(F: Monad<F>, crossinline f: (Option<A>) -> Option<B>): OptionT<F, B> =
-            OptionT(F.map(value, { f(it) }))
+    inline fun <B> transform(crossinline f: (Option<A>) -> Option<B>): OptionT<F, B> =
+            OptionT(instance<Functor<F>>().map(value, { f(it) }))
 
-    inline fun <B> subflatMap(F: Monad<F>, crossinline f: (A) -> Option<B>): OptionT<F, B> =
-            transform(F, { it.flatMap(f) })
+    inline fun <B> subflatMap(crossinline f: (A) -> Option<B>): OptionT<F, B> =
+            transform({ it.flatMap(f) })
 
     //TODO: add toRight() and toLeft() once EitherT it's available
 }

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -24,20 +24,21 @@ typealias OptionTF<F> = HK<OptionT.F, F>
  *
  * It may also be said that [OptionT] is a monad transformer for [Option].
  */
-data class OptionT<F, A>(val value: HK<F, Option<A>>) : OptionTKind<F, A> {
+data class OptionT<F, A>(val MF : Monad<F>, val value: HK<F, Option<A>>) : OptionTKind<F, A> {
 
     class F private constructor()
 
     companion object {
-        fun <M, A> pure(a: A): OptionT<M, A> = OptionT(instance<Applicative<M>>().pure(Option.Some(a)))
 
-        fun <M> none(): OptionT<M, Nothing> = OptionT(instance<Applicative<M>>().pure(Option.None))
+        inline fun <reified F, A> pure(a: A, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(Option.Some(a)))
 
-        fun <M, A> fromOption(value: Option<A>): OptionT<M, A> = OptionT(instance<Applicative<M>>().pure(value))
+        inline fun <reified F> none(MF : Monad<F> = monad<F>()): OptionT<F, Nothing> = OptionT(MF, MF.pure(Option.None))
+
+        inline fun <reified F, A> fromOption(value: Option<A>, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(value))
     }
 
     inline fun <B> fold(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
-            instance<Functor<F>>().map(value, { option -> option.fold({ default() }, { f(it) }) })
+            MF.map(value, { option -> option.fold({ default() }, { f(it) }) })
 
     inline fun <B> cata(F: Functor<F>, crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
             fold({ default() }, { f(it) })
@@ -45,44 +46,47 @@ data class OptionT<F, A>(val value: HK<F, Option<A>>) : OptionTKind<F, A> {
     inline fun <B> flatMap(crossinline f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF({ it -> f(it).value })
 
     inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> =
-            OptionT(instance<Monad<F>>().flatMap(value, { option -> option.fold({ instance<Applicative<F>>().pure(Option.None) }, { f(it) }) }))
+            OptionT(MF, MF.flatMap(value, { option -> option.fold({ MF.pure(Option.None) }, { f(it) }) }))
 
-    fun <B> liftF(fa: HK<F, B>): OptionT<F, B> = OptionT(instance<Functor<F>>().map(fa, { Option.Some(it) }))
+    fun <B> liftF(fa: HK<F, B>): OptionT<F, B> = OptionT(MF, MF.map(fa, { Option.Some(it) }))
 
     inline fun <B> semiflatMap(crossinline f: (A) -> HK<F, B>): OptionT<F, B> =
             flatMap({ option -> liftF(f(option)) })
 
     inline fun <B> map(crossinline f: (A) -> B): OptionT<F, B> =
-            OptionT(instance<Functor<F>>().map(value, { it.map(f) }))
+            OptionT(MF, MF.map(value, { it.map(f) }))
 
-    fun getOrElse(default: () -> A): HK<F, A> = instance<Functor<F>>().map(value, { it.getOrElse(default) })
+    fun getOrElse(default: () -> A): HK<F, A> = MF.map(value, { it.getOrElse(default) })
 
-    inline fun getOrElseF(crossinline default: () -> HK<F, A>): HK<F, A> = instance<Monad<F>>().flatMap(value, { it.fold(default, { instance<Applicative<F>>().pure(it) }) })
+    inline fun getOrElseF(crossinline default: () -> HK<F, A>): HK<F, A> = MF.flatMap(value, { it.fold(default, { MF.pure(it) }) })
 
-    inline fun filter(crossinline p: (A) -> Boolean): OptionT<F, A> = OptionT(instance<Functor<F>>().map(value, { it.filter(p) }))
+    inline fun filter(crossinline p: (A) -> Boolean): OptionT<F, A> = OptionT(MF, MF.map(value, { it.filter(p) }))
 
-    inline fun forall(crossinline p: (A) -> Boolean): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.forall(p) })
+    inline fun forall(crossinline p: (A) -> Boolean): HK<F, Boolean> = MF.map(value, { it.forall(p) })
 
-    fun isDefined(): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.isDefined })
+    fun isDefined(): HK<F, Boolean> = MF.map(value, { it.isDefined })
 
-    fun isEmpty(): HK<F, Boolean> = instance<Functor<F>>().map(value, { it.isEmpty })
+    fun isEmpty(): HK<F, Boolean> = MF.map(value, { it.isEmpty })
 
     inline fun orElse(crossinline default: () -> OptionT<F, A>): OptionT<F, A> =
             orElseF({ default().value })
 
     inline fun orElseF(crossinline default: () -> HK<F, Option<A>>): OptionT<F, A> =
-            OptionT(instance<Monad<F>>().flatMap(value) {
+            OptionT(MF, MF.flatMap(value) {
                 when (it) {
-                    is Option.Some<A> -> instance<Applicative<F>>().pure(it)
+                    is Option.Some<A> -> MF.pure(it)
                     is Option.None -> default()
                 }
             })
 
     inline fun <B> transform(crossinline f: (Option<A>) -> Option<B>): OptionT<F, B> =
-            OptionT(instance<Functor<F>>().map(value, { f(it) }))
+            OptionT(MF, MF.map(value, { f(it) }))
 
     inline fun <B> subflatMap(crossinline f: (A) -> Option<B>): OptionT<F, B> =
             transform({ it.flatMap(f) })
 
     //TODO: add toRight() and toLeft() once EitherT it's available
 }
+
+
+inline fun <reified F, A> optionT(value: HK<F, Option<A>>, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, value)

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -30,9 +30,9 @@ data class OptionT<F, A>(val MF: Monad<F>, val value: HK<F, Option<A>>) : Option
 
     companion object {
 
-        inline operator fun <reified F, A> invoke(value: HK<F, Option<A>>, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, value)
+        inline operator fun <reified F, A> invoke(value: HK<F, Option<A>>, MF: Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, value)
 
-        inline fun <reified F, A> pure(a: A, MF : Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(Option.Some(a)))
+        inline fun <reified F, A> pure(a: A, MF: Monad<F> = monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(Option.Some(a)))
 
         inline fun <reified F> none(MF: Monad<F> = monad<F>()): OptionT<F, Nothing> = OptionT(MF, MF.pure(Option.None))
 

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -89,5 +89,3 @@ data class OptionT<F, A>(val MF: Monad<F>, val value: HK<F, Option<A>>) : Option
 
     //TODO: add toRight() and toLeft() once EitherT it's available
 }
-
-

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -9,10 +9,11 @@ inline fun <D, A> ((D) -> A).reader(): ReaderT<Id.F, D, A> = Reader(this)
 fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A = this.run(d).value()
 
 object Reader {
-    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> = Kleisli(run.andThen { Id(it) }, Id)
 
-    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> = KleisliC.pure<Id.F, D, A>(x)
+    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> = Kleisli(Id, run.andThen { Id(it) })
 
-    fun <D> ask(): ReaderT<Id.F, D, D> = KleisliC.ask<Id.F, D>()
+    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> = Kleisli.pure<Id.F, D, A>(Id, x)
+
+    fun <D> ask(): ReaderT<Id.F, D, D> = Kleisli.ask<Id.F, D>(Id)
 
 }

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -1,33 +1,18 @@
 package katz
 
-typealias ReaderKind<D, A> = Kleisli<Id.F, D, A>
-
-class Reader<D, A>(val k: ReaderKind<D, A>) {
-
-    companion object Factory {
-
-        operator fun <D, A> invoke(fa : (D) -> A): Reader<D, A> = Reader(Kleisli(fa.andThen { Id(it) }))
-
-        fun <D, A> pure(x: A): Reader<D, A> = Reader { _ -> x }
-
-        fun <D> ask(): Reader<D, D> = Reader { it }
-
-    }
-
-    fun <DD> local(f: (DD) -> D): Reader<DD, A> = Reader(k.local(f))
-
-}
-
 infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C = { a: A -> this(f(a)) }
 
 infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C = { a: A -> g(this(a)) }
 
-fun <D, A, B> Reader<D, A>.map(fa: (A) -> B): Reader<D, B> = Reader(k.map(fa.andThen { Id(it).value }))
+inline fun <D, A> ((D) -> A).reader(): ReaderT<Id.F, D, A> = Reader(this)
 
-fun <D, A, B> Reader<D, A>.flatMap(fa: (A) -> Reader<D, B>): Reader<D, B> = Reader(k.flatMap(fa.andThen { it.k }))
+fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A = this.run(d).value()
 
-fun <D, A, B> Reader<D, A>.zip(o: Reader<D, B>) = Reader(k.zip(o.k))
+object Reader {
+    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> = Kleisli(run.andThen { Id(it) }, Id)
 
-inline fun <reified D, A> Reader<D, A>.run(d : D): A = k.run(d).value()
+    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> = KleisliC.pure<Id.F, D, A>(x)
 
-fun <D, A> ((D) -> A).reader(): Reader<D, A> = Reader(this)
+    fun <D> ask(): ReaderT<Id.F, D, D> = KleisliC.ask<Id.F, D>()
+
+}

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -22,12 +22,12 @@ infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C = { a: A -> this(f
 
 infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C = { a: A -> g(this(a)) }
 
-fun <D, A, B> Reader<D, A>.map(fa: (A) -> B): Reader<D, B> = Reader(k.map(IdMonad, fa.andThen { Id(it).value }))
+fun <D, A, B> Reader<D, A>.map(fa: (A) -> B): Reader<D, B> = Reader(k.map(fa.andThen { Id(it).value }))
 
-fun <D, A, B> Reader<D, A>.flatMap(fa: (A) -> Reader<D, B>): Reader<D, B> = Reader(k.flatMap(IdMonad, fa.andThen { it.k }))
+fun <D, A, B> Reader<D, A>.flatMap(fa: (A) -> Reader<D, B>): Reader<D, B> = Reader(k.flatMap(fa.andThen { it.k }))
 
-fun <D, A, B> Reader<D, A>.zip(o: Reader<D, B>) = Reader(k.zip(IdMonad, o.k))
+fun <D, A, B> Reader<D, A>.zip(o: Reader<D, B>) = Reader(k.zip(o.k))
 
-fun <D, A> Reader<D, A>.run(d : D): A = k.run(d).value()
+inline fun <reified D, A> Reader<D, A>.run(d : D): A = k.run(d).value()
 
 fun <D, A> ((D) -> A).reader(): Reader<D, A> = Reader(this)

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -16,12 +16,13 @@
 
 package katz
 
-interface Functor<F> {
+class CoproductComonad<F, G>(val FC : Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>> {
 
-    fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
+    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): CoproductKind<F, G, B> =
+        fa.ev().coflatMap(FC, GC, f)
 
-    fun <A, B> lift(f: (A) -> B): (HK<F, A>) -> HK<F, B> =
-            { fa: HK<F, A> ->
-                map(fa, f)
-            }
+
+    override fun <A> extract(fa: CoproductKind<F, G, A>): A =
+        fa.ev().extract(FC, GC)
+
 }

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -24,4 +24,6 @@ class CoproductComonad<F, G> : Comonad<CoproductFG<F, G>>, GlobalInstance<Comona
     override fun <A> extract(fa: CoproductKind<F, G, A>): A =
             fa.ev().extract()
 
+    override fun <A, B> map(fa: HK<CoproductFG<F, G>, A>, f: (A) -> B): HK<CoproductFG<F, G>, B> = fa.ev().map(f)
+
 }

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -16,12 +16,12 @@
 
 package katz
 
-class CoproductComonad<F, G>(val FC: Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>>, GlobalInstance<Comonad<CoproductFG<F, G>>>() {
+class CoproductComonad<F, G> : Comonad<CoproductFG<F, G>>, GlobalInstance<Comonad<CoproductFG<F, G>>>() {
 
     override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): Coproduct<F, G, B> =
-            fa.ev().coflatMap(FC, GC, f)
+            fa.ev().coflatMap(f)
 
     override fun <A> extract(fa: CoproductKind<F, G, A>): A =
-            fa.ev().extract(FC, GC)
+            fa.ev().extract()
 
 }

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-class CoproductComonad<F, G>(val FC : Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>> {
+class CoproductComonad<F, G>(val FC : Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>>, GlobalInstance<Comonad<CoproductFG<F, G>>>() {
 
     override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): CoproductKind<F, G, B> =
         fa.ev().coflatMap(FC, GC, f)

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-class CoproductComonad<F, G> : Comonad<CoproductFG<F, G>>, GlobalInstance<Comonad<CoproductFG<F, G>>>() {
+class CoproductComonad<F, G> : Comonad<CoproductFG<F, G>> {
 
     override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): Coproduct<F, G, B> =
             fa.ev().coflatMap(f)

--- a/katz/src/main/kotlin/katz/instances/EitherMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/EitherMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-class EitherMonad<L> : Monad<EitherF<L>>, GlobalInstance<Monad<Either.F>>() {
+class EitherMonad<L> : Monad<EitherF<L>> {
     override fun <A> pure(a: A): Either<L, A> = Either.Right(a)
 
     override fun <A, B> flatMap(fa: EitherKind<L, A>, f: (A) -> EitherKind<L, B>): Either<L, B> {

--- a/katz/src/main/kotlin/katz/instances/EitherMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/EitherMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object EitherMonad : Monad<HK<Either.F, *>> {
+object EitherMonad : Monad<HK<Either.F, *>>, GlobalInstance<Monad<Either.F>>() {
     override fun <A> pure(a: A): HK2<Either.F, *, A> =
             Either.Right(a)
 

--- a/katz/src/main/kotlin/katz/instances/IdMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IdMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object IdMonad : Monad<Id.F>, GlobalInstance<Monad<Id.F>>() {
+interface IdMonad : Monad<Id.F> {
 
     override fun <A, B> map(fa: IdKind<A>, f: (A) -> B): Id<B> =
             fa.ev().map(f)
@@ -26,7 +26,3 @@ object IdMonad : Monad<Id.F>, GlobalInstance<Monad<Id.F>>() {
     override fun <A, B> flatMap(fa: IdKind<A>, f: (A) -> IdKind<B>): Id<B> =
             fa.ev().flatMap { f(it).ev() }
 }
-
-fun <A> IdKind<A>.ev(): Id<A> = this as Id<A>
-
-fun <A> IdKind<A>.value(): A = this.ev().value

--- a/katz/src/main/kotlin/katz/instances/IdMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IdMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object IdMonad : Monad<Id.F>, GlobalInstance<Monad<Id.F>>(){
+object IdMonad : Monad<Id.F>, GlobalInstance<Monad<Id.F>>() {
 
     override fun <A, B> map(fa: IdKind<A>, f: (A) -> B): Id<B> =
             fa.ev().map(f)

--- a/katz/src/main/kotlin/katz/instances/IdMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IdMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object IdMonad : Monad<Id.F> {
+object IdMonad : Monad<Id.F>, GlobalInstance<Monad<Id.F>>(){
 
     override fun <A, B> map(fa: HK<Id.F, A>, f: (A) -> B): HK<Id.F, B> =
             fa.ev().map(f)

--- a/katz/src/main/kotlin/katz/instances/IorMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IorMonad.kt
@@ -16,9 +16,9 @@
 
 package katz
 
-class IorMonad<L>(val AA: Semigroup<L>) : Monad<HK<Ior.F, L>> {
+class IorMonad<L> : Monad<HK<Ior.F, L>> {
     override fun <A, B> flatMap(fa: IorKind<L, A>, f: (A) -> IorKind<L, B>): Ior<L, B> =
-            fa.ev().flatMap(AA) { f(it).ev() }
+            fa.ev().flatMap { f(it).ev() }
 
     override fun <A> pure(a: A): Ior<L, A> = Ior.Right(a)
 

--- a/katz/src/main/kotlin/katz/instances/IorMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IorMonad.kt
@@ -16,9 +16,9 @@
 
 package katz
 
-class IorMonad<L> : Monad<HK<Ior.F, L>> {
+class IorMonad<L>(val SL: Semigroup<L>) : Monad<HK<Ior.F, L>> {
     override fun <A, B> flatMap(fa: IorKind<L, A>, f: (A) -> IorKind<L, B>): Ior<L, B> =
-            fa.ev().flatMap { f(it).ev() }
+            fa.ev().flatMap(SL, { f(it).ev() })
 
     override fun <A> pure(a: A): Ior<L, A> = Ior.Right(a)
 

--- a/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object NonEmptyListMonad : Monad<NonEmptyList.F> {
+object NonEmptyListMonad : Monad<NonEmptyList.F>, GlobalInstance<Monad<NonEmptyList.F>>() {
 
     override fun <A, B> map(fa: HK<NonEmptyList.F, A>, f: (A) -> B): HK<NonEmptyList.F, B> =
             fa.ev().map(f)

--- a/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-object NonEmptyListMonad : Monad<NonEmptyList.F>, GlobalInstance<Monad<NonEmptyList.F>>() {
+interface NonEmptyListMonad : Monad<NonEmptyList.F> {
 
     override fun <A, B> map(fa: NonEmptyListKind<A>, f: (A) -> B): NonEmptyList<B> =
             fa.ev().map(f)

--- a/katz/src/main/kotlin/katz/instances/OptionMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionMonad.kt
@@ -16,7 +16,8 @@
 
 package katz
 
-object OptionMonad : Monad<Option.F> {
+object OptionMonad :
+        Monad<Option.F>, GlobalInstance<Monad<Option.F>>() {
 
     override fun <A, B> map(fa: HK<Option.F, A>, f: (A) -> B): HK<Option.F, B> =
             fa.ev().map(f)
@@ -29,3 +30,4 @@ object OptionMonad : Monad<Option.F> {
 }
 
 fun <A> HK<Option.F, A>.ev(): Option<A> = this as Option<A>
+

--- a/katz/src/main/kotlin/katz/instances/OptionMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionMonad.kt
@@ -16,8 +16,8 @@
 
 package katz
 
-object OptionMonad :
-        Monad<Option.F>, GlobalInstance<Monad<Option.F>>() {
+interface OptionMonad :
+        Monad<Option.F> {
 
     override fun <A, B> map(fa: OptionKind<A>, f: (A) -> B): Option<B> =
             fa.ev().map(f)

--- a/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
@@ -16,14 +16,14 @@
 
 package katz
 
-class OptionTMonad<F>(val M: Monad<F>) : Monad<OptionTF<F>> {
-    override fun <A> pure(a: A): OptionT<F, A> = OptionT.pure(M, a)
+class OptionTMonad<F> : Monad<OptionTF<F>> {
+    override fun <A> pure(a: A): OptionT<F, A> = OptionT.pure(a)
 
     override fun <A, B> flatMap(fa: OptionTKind<F, A>, f: (A) -> OptionTKind<F, B>): OptionT<F, B> =
-            fa.ev().flatMap(M, { f(it).ev() })
+            fa.ev().flatMap { f(it).ev() }
 
     override fun <A, B> map(fa: OptionTKind<F, A>, f: (A) -> B): OptionT<F, B> =
-            fa.ev().map(M, f)
+            fa.ev().map(f)
 }
 
 fun <F, A> OptionTKind<F, A>.ev(): OptionT<F, A> = this as OptionT<F, A>

--- a/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
@@ -16,8 +16,8 @@
 
 package katz
 
-class OptionTMonad<F> : Monad<OptionTF<F>> {
-    override fun <A> pure(a: A): OptionT<F, A> = OptionT.pure(a)
+class OptionTMonad<F>(val MF : Monad<F>) : Monad<OptionTF<F>> {
+    override fun <A> pure(a: A): OptionT<F, A> = OptionT(MF, MF.pure(Option(a)))
 
     override fun <A, B> flatMap(fa: OptionTKind<F, A>, f: (A) -> OptionTKind<F, B>): OptionT<F, B> =
             fa.ev().flatMap { f(it).ev() }

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -29,5 +29,5 @@ package katz
 //}
 
 object IntSemigroup : Semigroup<Int>, GlobalInstance<Semigroup<Int>>() {
-    override fun combine(a: Int, b: Int): Int = a
+    override fun combine(a: Int, b: Int): Int = a + b
 }

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -16,18 +16,14 @@
 
 package katz
 
-/**
- * Eagerly initialize all instances
- **/
-//class Bootstrap() {
-//    companion object {
-//        init {
-//            println("called!")
-//            listOf(EitherMonad, IdMonad, NonEmptyListMonad, OptionMonad)
-//        }
-//    }
-//}
+object IntMonoid : Monoid<Int>, GlobalInstance<Monoid<Int>>() {
+    override fun empty(): Int = 0
 
-object IntSemigroup : Semigroup<Int>, GlobalInstance<Semigroup<Int>>() {
     override fun combine(a: Int, b: Int): Int = a + b
+}
+
+inline fun <reified A> ListMonoid(): Monoid<List<A>> = object : Monoid<List<A>>, GlobalInstance<Monoid<List<A>>>() {
+    override fun empty(): List<A> = emptyList()
+
+    override fun combine(a: List<A>, b: List<A>): List<A> = a + b
 }

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,3 @@
 
 package katz
 
-interface Semigroup<A> {
-    /**
-     * Combine two [A] values.
-     */
-    fun combine(a: A, b: A): A
-
-    /**
-     * Combine an array of [A] values.
-     */
-    fun combineAll(vararg elems: A): A = combineAll(elems.asList())
-
-    /**
-     * Combine a collection of [A] values.
-     */
-    fun combineAll(elems: Collection<A>): A = elems.reduce { a, b -> combine(a, b) }
-}

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -16,3 +16,21 @@
 
 package katz
 
+/**
+ * Eagerly initialize all instances
+ **/
+//class Bootstrap() {
+//    companion object {
+//        init {
+//            println("called!")
+//            listOf(EitherMonad, IdMonad, NonEmptyListMonad, OptionMonad)
+//        }
+//    }
+//}
+
+
+object Serializable {
+    init {
+        println("boom")
+    }
+}

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -28,9 +28,6 @@ package katz
 //    }
 //}
 
-
-object Serializable {
-    init {
-        println("boom")
-    }
+object IntSemigroup : Semigroup<Int>, GlobalInstance<Semigroup<Int>>() {
+    override fun combine(a: Int, b: Int): Int = a
 }

--- a/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
@@ -292,3 +292,6 @@ fun <HKF, A, B, C, D, E, F, G, H, I, J, Z> Applicative<HKF>.map(
         j: HK<HKF, J>,
         lbd: (Tuple10<A, B, C, D, E, F, G, H, I, J>) -> Z): HK<HKF, Z> =
         this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j), lbd)
+
+inline fun <reified F> applicative(): Applicative<F> =
+        instance(InstanceParametrizedType(Applicative::class.java, listOf(F::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
@@ -18,7 +18,7 @@
 
 package katz
 
-interface Applicative<F> : Functor<F> {
+interface Applicative<F> : Functor<F>, Typeclass {
 
     fun <A> pure(a: A): HK<F, A>
 

--- a/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface ApplicativeError<F, E> : Applicative<F> {
+interface ApplicativeError<F, E> : Applicative<F>, Typeclass  {
 
     fun <A> raiseError(e: E): HK<F, A>
 

--- a/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface ApplicativeError<F, E> : Applicative<F>, Typeclass  {
+interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
 
     fun <A> raiseError(e: E): HK<F, A>
 

--- a/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
@@ -30,3 +30,6 @@ interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
                 pure(Either.Left(it))
             }
 }
+
+inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> =
+        instance(InstanceParametrizedType(Monad::class.java, listOf(F::class.java, E::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
@@ -16,12 +16,13 @@
 
 package katz
 
-interface Functor<F> {
+/**
+ * The dual of monads, used to extract values from F
+ */
+interface Comonad<F> {
 
-    fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
+    fun <A, B> coflatMap(fa: HK<F, A>, f: (HK<F, A>) -> B): HK<F, B>
 
-    fun <A, B> lift(f: (A) -> B): (HK<F, A>) -> HK<F, B> =
-            { fa: HK<F, A> ->
-                map(fa, f)
-            }
+    fun <A> extract(fa: HK<F, A>) : A
+
 }

--- a/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
@@ -19,10 +19,13 @@ package katz
 /**
  * The dual of monads, used to extract values from F
  */
-interface Comonad<F> : Typeclass {
+interface Comonad<F> : Functor<F>, Typeclass {
 
     fun <A, B> coflatMap(fa: HK<F, A>, f: (HK<F, A>) -> B): HK<F, B>
 
     fun <A> extract(fa: HK<F, A>) : A
 
 }
+
+inline fun <reified F> comonad(): Comonad<F> =
+        instance(InstanceParametrizedType(Comonad::class.java, listOf(F::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
@@ -19,7 +19,7 @@ package katz
 /**
  * The dual of monads, used to extract values from F
  */
-interface Comonad<F> {
+interface Comonad<F> : Typeclass {
 
     fun <A, B> coflatMap(fa: HK<F, A>, f: (HK<F, A>) -> B): HK<F, B>
 

--- a/katz/src/main/kotlin/katz/typeclasses/Functor.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Functor.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface Functor<F> : Typeclass  {
+interface Functor<F> : Typeclass {
 
     fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
 

--- a/katz/src/main/kotlin/katz/typeclasses/Functor.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Functor.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface Functor<F> {
+interface Functor<F> : Typeclass  {
 
     fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
 

--- a/katz/src/main/kotlin/katz/typeclasses/Functor.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Functor.kt
@@ -25,3 +25,6 @@ interface Functor<F> : Typeclass {
                 map(fa, f)
             }
 }
+
+inline fun <reified F> functor(): Functor<F> =
+        instance(InstanceParametrizedType(Functor::class.java, listOf(F::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Inject.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Inject.kt
@@ -16,12 +16,15 @@
 
 package katz
 
-interface Functor<F> {
+/**
+ * Inject type class as described in "Data types a la carte" (Swierstra 2008).
+ *
+ * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
+ */
+interface Inject<F, G> {
 
-    fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
+    fun inj(): FunctionK<F, G>
 
-    fun <A, B> lift(f: (A) -> B): (HK<F, A>) -> HK<F, B> =
-            { fa: HK<F, A> ->
-                map(fa, f)
-            }
+    fun <A> invoke(fa: HK<F, A>): HK<G, A> = inj()(fa)
+
 }

--- a/katz/src/main/kotlin/katz/typeclasses/Inject.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Inject.kt
@@ -21,7 +21,7 @@ package katz
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
  */
-interface Inject<F, G> {
+interface Inject<F, G> : Typeclass  {
 
     fun inj(): FunctionK<F, G>
 

--- a/katz/src/main/kotlin/katz/typeclasses/Inject.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Inject.kt
@@ -28,3 +28,6 @@ interface Inject<in F, out G> : Typeclass {
     fun <A> invoke(fa: HK<F, A>): HK<G, A> = inj()(fa)
 
 }
+
+inline fun <reified F, reified G> inject(): Inject<F, G> =
+        instance(InstanceParametrizedType(Inject::class.java, listOf(F::class.java, G::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Inject.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Inject.kt
@@ -21,7 +21,7 @@ package katz
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
  */
-interface Inject<F, G> : Typeclass  {
+interface Inject<in F, out G> : Typeclass {
 
     fun inj(): FunctionK<F, G>
 

--- a/katz/src/main/kotlin/katz/typeclasses/Monad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Monad.kt
@@ -80,3 +80,6 @@ fun <F, B> Monad<F>.binding(c: suspend MonadContinuation<F, *>.() -> HK<F, B>): 
     f.startCoroutine(continuation, continuation)
     return continuation.returnedMonad
 }
+
+inline fun <reified F> monad(): Monad<F> =
+        instance(InstanceParametrizedType(Monad::class.java, listOf(F::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Monad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Monad.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.experimental.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
 import kotlin.coroutines.experimental.startCoroutine
 
-interface Monad<F> : Applicative<F> {
+interface Monad<F> : Applicative<F>, Typeclass {
 
     fun <A, B> flatMap(fa: HK<F, A>, f: (A) -> HK<F, B>): HK<F, B>
 

--- a/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
@@ -20,7 +20,7 @@ import java.io.Serializable
 import kotlin.coroutines.experimental.RestrictsSuspension
 import kotlin.coroutines.experimental.startCoroutine
 
-interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F> {
+interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, Typeclass  {
     fun <A> ensure(fa: HK<F, A>, error: () -> E, predicate: (A) -> Boolean): HK<F, A> =
             flatMap(fa, {
                 if (predicate(it)) pure(it)

--- a/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
@@ -20,7 +20,7 @@ import java.io.Serializable
 import kotlin.coroutines.experimental.RestrictsSuspension
 import kotlin.coroutines.experimental.startCoroutine
 
-interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, Typeclass  {
+interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, Typeclass {
     fun <A> ensure(fa: HK<F, A>, error: () -> E, predicate: (A) -> Boolean): HK<F, A> =
             flatMap(fa, {
                 if (predicate(it)) pure(it)

--- a/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
@@ -50,3 +50,6 @@ fun <F, B> MonadError<F, Throwable>.binding(c: suspend MonadErrorContinuation<F,
     f.startCoroutine(continuation, continuation)
     return continuation.returnedMonad
 }
+
+inline fun <reified F, reified E> monadError(): MonadError<F, E> =
+        instance(InstanceParametrizedType(Functor::class.java, listOf(F::class.java, E::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Monoid.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Monoid.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 The Katz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package katz
+
+interface Monoid<A> : Semigroup<A> {
+    /**
+     * A zero value for this A
+     */
+    fun empty(): A
+
+}
+
+inline fun <reified A> monoid(): Monoid<A> =
+        instance(InstanceParametrizedType(Monoid::class.java, listOf(A::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
@@ -32,3 +32,6 @@ interface Semigroup<A> : Typeclass {
      */
     fun combineAll(elems: Collection<A>): A = elems.reduce { a, b -> combine(a, b) }
 }
+
+inline fun <reified A> semigroup(): Semigroup<A> =
+        instance(InstanceParametrizedType(Semigroup::class.java, listOf(A::class.java)))

--- a/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface Semigroup<A> : Typeclass  {
+interface Semigroup<A> : Typeclass {
     /**
      * Combine two [A] values.
      */

--- a/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
@@ -16,7 +16,7 @@
 
 package katz
 
-interface Semigroup<A> {
+interface Semigroup<A> : Typeclass  {
     /**
      * Combine two [A] values.
      */

--- a/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
@@ -16,12 +16,19 @@
 
 package katz
 
-class CoproductComonad<F, G>(val FC : Comonad<F>, val GC: Comonad<G>) : Comonad<CoproductFG<F, G>> {
+interface Semigroup<A> {
+    /**
+     * Combine two [A] values.
+     */
+    fun combine(a: A, b: A): A
 
-    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): CoproductKind<F, G, B> =
-        fa.ev().coflatMap(FC, GC, f)
+    /**
+     * Combine an array of [A] values.
+     */
+    fun combineAll(vararg elems: A): A = combineAll(elems.asList())
 
-    override fun <A> extract(fa: CoproductKind<F, G, A>): A =
-        fa.ev().extract(FC, GC)
-
+    /**
+     * Combine a collection of [A] values.
+     */
+    fun combineAll(elems: Collection<A>): A = elems.reduce { a, b -> combine(a, b) }
 }

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -137,15 +137,13 @@ open class GlobalInstance<T : Typeclass> : TypeLiteral<T>() {
      */
     fun recurseInterfaces(c: Class<*>) {
         return when {
-            c.interfaces.isEmpty() -> println("$c has no interfaces")
+            c.interfaces.isEmpty() -> Unit
             else -> {
                     c.interfaces.filter {
                         it != Typeclass::class.java && Typeclass::class.java.isAssignableFrom(it)
                     }.forEach { i ->
                         val instanceType = InstanceParametrizedType(i, listOf(type.actualTypeArguments[0]))
-                        println("Considering interface: $i for type: $type and instance type: $instanceType")
                         GlobalInstances.putIfAbsent(instanceType, this)
-                        println("Thread: ${Thread.currentThread().name} Time: ${System.nanoTime()} : registered global instance for type class : $instanceType")
                         recurseInterfaces(i)
                     }
             }

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -20,18 +20,63 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Marker trait that all Functional typeclasses such as Monad, Functor, etc... must implement to be considered
+ * candidates to pair with global instances
+ */
 interface Typeclass
 
-open class GlobalInstance<T : Typeclass> {
-    val type: Type
-        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
+/**
+ * A parametrized type calculated from walking up the interface chain in a Typeclass and finding other relevant
+ * typeclasses that should be registered
+ */
+data class InstanceParametrizedType(val raw: Type, val typeArgs: List<Type>) : ParameterizedType {
+    override fun getRawType(): Type = raw
 
-    init {
-        GlobalInstances.put(type, this)
-        println("Registered $this -> $type")
-    }
+    override fun getOwnerType(): Type = null as Type
+
+    override fun getActualTypeArguments(): Array<Type> = typeArgs.toTypedArray()
 }
 
+/**
+ * Auto registers subtypes as a global instance for all the functional typeclass interfaces they implement
+ */
+open class GlobalInstance<T : Typeclass>() {
+
+    init {
+        recurseInterfaces(javaClass)
+    }
+
+    /**
+     * The original typeclass parametrization that trigger this interface lookup
+     */
+    val type: ParameterizedType
+        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0] as ParameterizedType
+
+    /**
+     * REcursively scan all implemented interfaces and add as global instances all the ones that match a Typeclass
+     */
+    fun recurseInterfaces(c : Class<*>) : Unit {
+        return when {
+            c.interfaces.isEmpty() -> println("$c has no interfaces")
+            else -> {
+                c.interfaces.filter {
+                    it != Typeclass::class.java && Typeclass::class.java.isAssignableFrom(it)
+                }.forEach { i ->
+                    val instanceType = InstanceParametrizedType(i, listOf(type.actualTypeArguments[0]))
+                    GlobalInstances.put(type, this)
+                    println("registered global instance for type class : $instanceType")
+                    recurseInterfaces(i)
+                }
+            }
+        }
+    }
+
+}
+
+/**
+ * Instrospects the generic type arguments to locate generic interfaces and their type args
+ */
 open class TypeLiteral<T> {
     val type: Type
         get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
@@ -39,6 +84,21 @@ open class TypeLiteral<T> {
 
 inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>() {}.type
 
+/**
+ * A concurrent hash map of local global instances that may be invoked at runtime as if they were implicitly summoned
+ */
 val GlobalInstances: MutableMap<Type, GlobalInstance<*>> = ConcurrentHashMap()
+
+/**
+ * Obtains a global registered typeclass instance when fast unsafe runtime lookups are desired over passing instances
+ * as args to functions. Use with care. This lookup will throw an exception if a typeclass is summoned and can't be found
+ * in the GlobalInstances map
+ */
+
+data class TypeClassInstanceNotFound(val type : Type)
+    : RuntimeException("$type not found in Global Typeclass Instances registry. " +
+        "Please ensure your instances implement `GlobalInstance<$type>` for automatic registration." +
+        "Alternatively invoke `GlobalInstances.put(typeLiteral<$type>(), instance)` if you wish to register " +
+        "or override a typeclass manually")
 
 inline fun <reified T : Typeclass> instance(): T = GlobalInstances.getValue(typeLiteral<T>()) as T

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -203,16 +203,8 @@ data class TypeClassInstanceNotFound(val type : Type)
         "Alternatively invoke `GlobalInstances.put(typeLiteral<$type>(), instance)` if you wish to register " +
         "or override a typeclass manually")
 
-inline fun <reified T : Typeclass> instance(): T {
-    val t = typeLiteral<T>()
+fun <T: Typeclass> instance(t : Type): T {
     if (GlobalInstances.containsKey(t))
         return GlobalInstances.getValue(t) as T
-    else throw TypeClassInstanceNotFound(t)
-}
-
-inline fun <reified F> monad(): Monad<F> {
-    val t = InstanceParametrizedType(Monad::class.java, listOf(typeLiteral<F>()))
-    if (GlobalInstances.containsKey(t))
-        return GlobalInstances.getValue(t) as Monad<F>
     else throw TypeClassInstanceNotFound(t)
 }

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 The Katz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package katz
+
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.concurrent.ConcurrentHashMap
+
+interface Typeclass
+
+open class GlobalInstance<T : Typeclass> {
+    val type: Type
+        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
+
+    init {
+        GlobalInstances.put(type, this)
+        println("Registered $this -> $type")
+    }
+}
+
+open class TypeLiteral<T> {
+    val type: Type
+        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
+}
+
+inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>() {}.type
+
+val GlobalInstances: MutableMap<Type, GlobalInstance<*>> = ConcurrentHashMap()
+
+inline fun <reified T : Typeclass> instance(): T = GlobalInstances.getValue(typeLiteral<T>()) as T

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -56,7 +56,7 @@ open class GlobalInstance<T : Typeclass>() {
     /**
      * REcursively scan all implemented interfaces and add as global instances all the ones that match a Typeclass
      */
-    fun recurseInterfaces(c : Class<*>) : Unit {
+    fun recurseInterfaces(c : Class<*>) {
         return when {
             c.interfaces.isEmpty() -> println("$c has no interfaces")
             else -> {
@@ -82,7 +82,7 @@ open class TypeLiteral<T> {
         get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
 }
 
-inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>() {}.type
+inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>(){}.type
 
 /**
  * A concurrent hash map of local global instances that may be invoked at runtime as if they were implicitly summoned

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -144,7 +144,7 @@ open class GlobalInstance<T : Typeclass> : TypeLiteral<T>() {
                     }.forEach { i ->
                         val instanceType = InstanceParametrizedType(i, listOf(type.actualTypeArguments[0]))
                         println("Considering interface: $i for type: $type and instance type: $instanceType")
-                        GlobalInstances.put(instanceType, this)
+                        GlobalInstances.putIfAbsent(instanceType, this)
                         println("Thread: ${Thread.currentThread().name} Time: ${System.nanoTime()} : registered global instance for type class : $instanceType")
                         recurseInterfaces(i)
                     }

--- a/katz/src/test/kotlin/instances/GlobalInstancesTest.kt
+++ b/katz/src/test/kotlin/instances/GlobalInstancesTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 The Katz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package katz
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.shouldBe
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class GlobalInstancesTest : UnitSpec() {
+
+    inline fun <reified F> testTypeclassHierarchyInference(a : Any) {
+        functor<F>() shouldBe a
+        applicative<F>() shouldBe a
+        monad<F>() shouldBe a
+    }
+
+    init {
+
+        "Id inference" {
+            testTypeclassHierarchyInference<Id.F>(Id)
+        }
+
+        "NonEmptyList monad inference" {
+            testTypeclassHierarchyInference<NonEmptyList.F>(NonEmptyList)
+        }
+
+        "Option monad inference" {
+            testTypeclassHierarchyInference<Option.F>(Option)
+        }
+    }
+}

--- a/katz/src/test/kotlin/katz/ReaderTest.kt
+++ b/katz/src/test/kotlin/katz/ReaderTest.kt
@@ -24,30 +24,30 @@ import org.junit.runner.RunWith
 class ReaderTest : UnitSpec() {
     init {
         "map should return mapped value" {
-            Reader<Int, Int> { it -> it * 2 }.map { it -> it * 3 }.run(2) shouldBe 12
+            Reader<Int, Int> { it -> it * 2 }.map { it -> it * 3 }.runId(2) shouldBe 12
         }
 
         "flatMap should map over the inner value" {
-            Reader<Int, Int> { it -> it * 2 }.flatMap { a -> Reader.pure<Int, Int>(a * 3) }
-                    .run(2) shouldBe 12
+            Reader<Int, Int> ({ it -> it * 2 }).flatMap { a -> Reader.pure<Int, Int>(a * 3) }
+                    .run(2).value() shouldBe 12
         }
 
         "zip should return a new Reader zipping two given ones" {
-            val r1 = Reader<Int, Int> { it -> it * 2 }
-            val r2 = Reader<Int, Int> { it -> it * 3 }
-            r1.zip(r2).run(2) shouldBe Pair(4, 6)
+            val r1 = Reader<Int, Int> ({ it -> it * 2 })
+            val r2 = Reader<Int, Int> ({ it -> it * 3 })
+            r1.zip(r2).run(2).value() shouldBe Pair(4, 6)
         }
 
         "local should switch context to be able to combine Readers with different contexts" {
-            val r = Reader<Int, Int> { it -> it * 2 }
-            r.local<Boolean> { it -> if (it) 1 else 3 }.run(false) shouldBe 6
-            r.local<Boolean> { it -> if (it) 1 else 3 }.run(true) shouldBe 2
+            val r = Reader<Int, Int> ({ it -> it * 2 })
+            r.local<Boolean> { it -> if (it) 1 else 3 }.runId(false) shouldBe 6
+            r.local<Boolean> { it -> if (it) 1 else 3 }.runId(true) shouldBe 2
         }
 
         "reader should lift a reader from any (A) -> B function" {
-            val r = { x: Int -> x * 2 }.reader()
-            r::class.java shouldBe Reader::class.java
-            r.run(2) shouldBe 4
+            val r = { x: Int -> Id(x * 2) }.reader()
+            r::class.java shouldBe Kleisli::class.java
+            r.runId(2).value() shouldBe 4
         }
     }
 }

--- a/katz/src/test/kotlin/katz/ReaderTest.kt
+++ b/katz/src/test/kotlin/katz/ReaderTest.kt
@@ -49,5 +49,6 @@ class ReaderTest : UnitSpec() {
             r::class.java shouldBe Kleisli::class.java
             r.runId(2).value() shouldBe 4
         }
+
     }
 }

--- a/katz/src/test/kotlin/katz/data/IorTest.kt
+++ b/katz/src/test/kotlin/katz/data/IorTest.kt
@@ -13,12 +13,12 @@ class IorTest : UnitSpec() {
             forAll { a: Int, b: String ->
                 {
 
-                    Ior.Right(b).flatMap(IntSemigroup) { Ior.Left(a) } == Ior.Left(a) &&
-                            Ior.Right(a).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Left(a).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Left(a) &&
-                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Left(a) } == Ior.Left(IntSemigroup.combine(a, a)) &&
-                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Both(a, b) } == Ior.Both(IntSemigroup.combine(a, a), b)
+                    Ior.Right(b).flatMap(IntMonoid) { Ior.Left(a) } == Ior.Left(a) &&
+                            Ior.Right(a).flatMap(IntMonoid) { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Left(a).flatMap(IntMonoid) { Ior.Right(b) } == Ior.Left(a) &&
+                            Ior.Both(a, b).flatMap(IntMonoid) { Ior.Left(a) } == Ior.Left(IntMonoid.combine(a, a)) &&
+                            Ior.Both(a, b).flatMap(IntMonoid) { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Both(a, b).flatMap(IntMonoid) { Ior.Both(a, b) } == Ior.Both(IntMonoid.combine(a, a), b)
                 }()
             }
         }
@@ -131,7 +131,7 @@ class IorTest : UnitSpec() {
 
         }
 
-        val intIorMonad = IorMonad(IntSemigroup)
+        val intIorMonad = IorMonad(IntMonoid)
 
         "Ior.monad.flatMap should combine left values" {
             val ior1 = Ior.Both(3, "Hello, world!")
@@ -143,7 +143,7 @@ class IorTest : UnitSpec() {
             forAll { a: Int ->
                 val x = { b: Int -> Ior.Right(b * a) }
                 val ior = Ior.Right(a)
-                ior.flatMap(IntSemigroup, x) == intIorMonad.flatMap(ior, x)
+                ior.flatMap(IntMonoid, x) == intIorMonad.flatMap(ior, x)
             }
         }
 

--- a/katz/src/test/kotlin/katz/data/IorTest.kt
+++ b/katz/src/test/kotlin/katz/data/IorTest.kt
@@ -12,29 +12,13 @@ class IorTest : UnitSpec() {
         "flatMap() should modify entity" {
             forAll { a: Int, b: String ->
                 {
-                    val intMonoidInstance: Semigroup<Int> = object : Semigroup<Int> {
-                        override fun combine(a: Int, b: Int): Int = a
-                    }
-                    Ior.Right(b).flatMap(intMonoidInstance) { Ior.Left(a) } == Ior.Left(a) &&
-                            Ior.Right(a).flatMap(intMonoidInstance) { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Left(a).flatMap(intMonoidInstance) { Ior.Right(b) } == Ior.Left(a) &&
-                            Ior.Both(a, b).flatMap(intMonoidInstance) { Ior.Left(a) } == Ior.Left(intMonoidInstance.combine(a, a)) &&
-                            Ior.Both(a, b).flatMap(intMonoidInstance) { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Both(a, b).flatMap(intMonoidInstance) { Ior.Both(a, b) } == Ior.Both(intMonoidInstance.combine(a, a), b)
-                }()
-            }
-        }
 
-        "flatMap() should combine with upper bound" {
-            forAll { a: String, b: Int ->
-                {
-                    val numberMonoidInstance: Semigroup<Number> = object : Semigroup<Number> {
-                        override fun combine(a: Number, b: Number): Number = a
-                    }
-                    val iorRightString: Ior<Int, String> = Ior.Right(a)
-                    val iorLeftNumberAsUpperBoundOfInt: Ior<Number, String> = Ior.Left(b)
-                    val iorResult: Ior<Number, String> = iorRightString.flatMap(numberMonoidInstance) { iorLeftNumberAsUpperBoundOfInt }
-                    iorResult == iorLeftNumberAsUpperBoundOfInt
+                    Ior.Right(b).flatMap { Ior.Left(a) } == Ior.Left(a) &&
+                            Ior.Right(a).flatMap { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Left(a).flatMap { Ior.Right(b) } == Ior.Left(a) &&
+                            Ior.Both(a, b).flatMap { Ior.Left(a) } == Ior.Left(IntSemigroup.combine(a, a)) &&
+                            Ior.Both(a, b).flatMap { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Both(a, b).flatMap { Ior.Both(a, b) } == Ior.Both(IntSemigroup.combine(a, a), b)
                 }()
             }
         }
@@ -147,10 +131,7 @@ class IorTest : UnitSpec() {
 
         }
 
-        val intMonoidInstance: Semigroup<Int> = object : Semigroup<Int> {
-            override fun combine(a: Int, b: Int): Int = a + b
-        }
-        val intIorMonad = IorMonad(intMonoidInstance)
+        val intIorMonad = IorMonad<Int>()
 
         "Ior.monad.flatMap should combine left values" {
             val ior1 = Ior.Both(3, "Hello, world!")
@@ -162,7 +143,7 @@ class IorTest : UnitSpec() {
             forAll { a: Int ->
                 val x = { b: Int -> Ior.Right(b * a) }
                 val ior = Ior.Right(a)
-                ior.flatMap(intIorMonad.AA, x) == intIorMonad.flatMap(ior, x)
+                ior.flatMap(x) == intIorMonad.flatMap(ior, x)
             }
         }
 

--- a/katz/src/test/kotlin/katz/data/IorTest.kt
+++ b/katz/src/test/kotlin/katz/data/IorTest.kt
@@ -13,12 +13,12 @@ class IorTest : UnitSpec() {
             forAll { a: Int, b: String ->
                 {
 
-                    Ior.Right(b).flatMap { Ior.Left(a) } == Ior.Left(a) &&
-                            Ior.Right(a).flatMap { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Left(a).flatMap { Ior.Right(b) } == Ior.Left(a) &&
-                            Ior.Both(a, b).flatMap { Ior.Left(a) } == Ior.Left(IntSemigroup.combine(a, a)) &&
-                            Ior.Both(a, b).flatMap { Ior.Right(b) } == Ior.Right(b) &&
-                            Ior.Both(a, b).flatMap { Ior.Both(a, b) } == Ior.Both(IntSemigroup.combine(a, a), b)
+                    Ior.Right(b).flatMap(IntSemigroup) { Ior.Left(a) } == Ior.Left(a) &&
+                            Ior.Right(a).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Left(a).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Left(a) &&
+                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Left(a) } == Ior.Left(IntSemigroup.combine(a, a)) &&
+                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Right(b) } == Ior.Right(b) &&
+                            Ior.Both(a, b).flatMap(IntSemigroup) { Ior.Both(a, b) } == Ior.Both(IntSemigroup.combine(a, a), b)
                 }()
             }
         }
@@ -131,7 +131,7 @@ class IorTest : UnitSpec() {
 
         }
 
-        val intIorMonad = IorMonad<Int>()
+        val intIorMonad = IorMonad(IntSemigroup)
 
         "Ior.monad.flatMap should combine left values" {
             val ior1 = Ior.Both(3, "Hello, world!")
@@ -143,7 +143,7 @@ class IorTest : UnitSpec() {
             forAll { a: Int ->
                 val x = { b: Int -> Ior.Right(b * a) }
                 val ior = Ior.Right(a)
-                ior.flatMap(x) == intIorMonad.flatMap(ior, x)
+                ior.flatMap(IntSemigroup, x) == intIorMonad.flatMap(ior, x)
             }
         }
 

--- a/katz/src/test/kotlin/katz/data/NonEmptyListTest.kt
+++ b/katz/src/test/kotlin/katz/data/NonEmptyListTest.kt
@@ -43,11 +43,11 @@ class NonEmptyListTest : UnitSpec() {
         "NonEmptyListMonad.flatMap should be consistent with NonEmptyList#flatMap" {
             val nel = NonEmptyList.of(1, 2)
             val nel2 = NonEmptyList.of(1, 2)
-            nel.flatMap { nel2 } shouldBe NonEmptyListMonad.flatMap(nel) { nel2 }
+            nel.flatMap { nel2 } shouldBe NonEmptyList.flatMap(nel) { nel2 }
         }
 
         "NonEmptyListMonad.binding should for comprehend over NonEmptyList" {
-            val result = NonEmptyListMonad.binding {
+            val result = NonEmptyList.binding {
                 val x = !NonEmptyList.of(1)
                 val y = NonEmptyList.of(2).bind()
                 val z = bind { NonEmptyList.of(3) }
@@ -57,7 +57,7 @@ class NonEmptyListTest : UnitSpec() {
         }
 
         "NonEmptyListMonad.binding should for comprehend over complex NonEmptyList" {
-            val result = NonEmptyListMonad.binding {
+            val result = NonEmptyList.binding {
                 val x = !NonEmptyList.of(1, 2)
                 val y = NonEmptyList.of(3).bind()
                 val z = bind { NonEmptyList.of(4) }
@@ -71,7 +71,7 @@ class NonEmptyListTest : UnitSpec() {
                 val nel: NonEmptyList<Int> = NonEmptyList(a, b)
                 val nel2 = NonEmptyList.of(1, 2)
                 val nel3 = NonEmptyList.of(3, 4, 5)
-                val result: HK<NonEmptyList.F, Int> = NonEmptyListMonad.binding {
+                val result: HK<NonEmptyList.F, Int> = NonEmptyList.binding {
                     val x = !nel
                     val y = nel2.bind()
                     val z = bind { nel3 }

--- a/katz/src/test/kotlin/katz/data/OptionTTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTTest.kt
@@ -26,7 +26,7 @@ class OptionTTest : UnitSpec() {
         "map should modify value" {
             forAll { a: String ->
                 val ot = OptionT(Id(Option.Some(a)))
-                val mapped = ot.map(IdMonad, { "$it power" })
+                val mapped = ot.map({ "$it power" })
                 val expected = OptionT(Id(Option.Some("$a power")))
 
                 mapped == expected
@@ -36,62 +36,64 @@ class OptionTTest : UnitSpec() {
         "flatMap should modify entity" {
             forAll { a: String ->
                 val ot = OptionT(NonEmptyList.of(Option.Some(a)))
-                val mapped = ot.flatMap(NonEmptyListMonad) { OptionT(NonEmptyList.of(Option.Some(3))) }
-                val expected = OptionT.pure(NonEmptyListMonad, 3)
+                val mapped = ot.flatMap{ OptionT(NonEmptyList.of(Option.Some(3))) }
+                val expected: OptionT<NonEmptyList.F, Int> = OptionT.pure(3)
 
                 mapped == expected
             }
 
             forAll { ignored: String ->
                 val ot = OptionT(NonEmptyList.of(Option.Some(ignored)))
-                val mapped = ot.flatMap(NonEmptyListMonad, { OptionT(NonEmptyList.of(Option.None)) })
-                val expected = OptionT.none(NonEmptyListMonad)
+                val mapped = ot.flatMap { OptionT(NonEmptyList.of(Option.None)) }
+                val expected = OptionT.none<NonEmptyList.F>()
 
                 mapped == expected
             }
 
-            OptionT.none(NonEmptyListMonad)
-                    .flatMap(NonEmptyListMonad, { OptionT(NonEmptyList.of(Option.Some(2))) }) shouldBe OptionT(NonEmptyList.of(Option.None))
+            OptionT.none<NonEmptyList.F>()
+                    .flatMap { OptionT(NonEmptyList.of(Option.Some(2))) } shouldBe OptionT(NonEmptyList.of(Option.None))
         }
 
         "from option should build a correct OptionT" {
             forAll { a: String ->
-                OptionT.fromOption(NonEmptyListMonad, Option.Some(a)) == OptionT.pure(NonEmptyListMonad, a)
+                OptionT.fromOption<NonEmptyList.F, String>(Option.Some(a)) == OptionT.pure<NonEmptyList.F, String>(a)
             }
         }
 
         "OptionTMonad.flatMap should be consistent with OptionT#flatMap" {
             forAll { a: Int ->
-                val x = { b: Int -> OptionT.pure(IdMonad, b * a) }
-                val option = OptionT.pure(IdMonad, a)
-                option.flatMap(IdMonad, x) == OptionTMonad(IdMonad).flatMap(option, x)
+                val x = { b: Int -> OptionT.pure<Id.F, Int>(b * a) }
+                val option = OptionT.pure<Id.F, Int>(a)
+                option.flatMap(x) == OptionTMonad<Id.F>().flatMap(option, x)
             }
         }
 
         "OptionTMonad.binding should for comprehend over option" {
-            val result = OptionTMonad(NonEmptyListMonad).binding {
-                val x = !OptionT.pure(NonEmptyListMonad, 1)
-                val y = OptionT.pure(NonEmptyListMonad, 1).bind()
-                val z = bind { OptionT.pure(NonEmptyListMonad, 1) }
+            val M = OptionTMonad<NonEmptyList.F>()
+            val result = M.binding {
+                val x = !M.pure(1)
+                val y = M.pure(1).bind()
+                val z = bind { M.pure(1) }
                 yields(x + y + z)
             }
-            result shouldBe OptionT.pure(NonEmptyListMonad, 3)
+            result shouldBe M.pure(3)
         }
 
         "Cartesian builder should build products over option" {
-            OptionTMonad(IdMonad).map(OptionT.pure(IdMonad, 1), OptionT.pure(IdMonad, "a"), OptionT.pure(IdMonad, true), { (a, b, c) ->
+            OptionTMonad<Id.F>().map(OptionT.pure(1), OptionT.pure("a"), OptionT.pure(true), { (a, b, c) ->
                 "$a $b $c"
-            }) shouldBe OptionT.pure(IdMonad, "1 a true")
+            }) shouldBe OptionT.pure<Id.F, String>("1 a true")
         }
 
         "Cartesian builder works inside for comprehensions" {
-            val result = OptionTMonad(NonEmptyListMonad).binding {
-                val (x, y, z) = !OptionTMonad(NonEmptyListMonad).tupled(OptionT.pure(NonEmptyListMonad, 1), OptionT.pure(NonEmptyListMonad, 1), OptionT.pure(NonEmptyListMonad, 1))
-                val a = OptionT.pure(NonEmptyListMonad, 1).bind()
-                val b = bind { OptionT.pure(NonEmptyListMonad, 1) }
+            val M = OptionTMonad<NonEmptyList.F>()
+            val result = M.binding {
+                val (x, y, z) = !M.tupled(M.pure(1), M.pure(1), M.pure(1))
+                val a = M.pure(1).bind()
+                val b = bind { M.pure(1) }
                 yields(x + y + z + a + b)
             }
-            result shouldBe OptionT.pure(NonEmptyListMonad, 5)
+            result shouldBe M.pure(5)
         }
     }
 }

--- a/katz/src/test/kotlin/katz/data/OptionTTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTTest.kt
@@ -25,9 +25,9 @@ class OptionTTest : UnitSpec() {
     init {
         "map should modify value" {
             forAll { a: String ->
-                val ot = optionT(Id(Option.Some(a)))
+                val ot = OptionT(Id(Option.Some(a)))
                 val mapped = ot.map({ "$it power" })
-                val expected = optionT(Id(Option.Some("$a power")))
+                val expected = OptionT(Id(Option.Some("$a power")))
 
                 mapped == expected
             }
@@ -35,23 +35,23 @@ class OptionTTest : UnitSpec() {
 
         "flatMap should modify entity" {
             forAll { a: String ->
-                val ot = optionT(NonEmptyList.of(Option.Some(a)))
-                val mapped = ot.flatMap{ optionT(NonEmptyList.of(Option.Some(3))) }
+                val ot = OptionT(NonEmptyList.of(Option.Some(a)))
+                val mapped = ot.flatMap{ OptionT(NonEmptyList.of(Option.Some(3))) }
                 val expected: OptionT<NonEmptyList.F, Int> = OptionT.pure(3)
 
                 mapped == expected
             }
 
             forAll { ignored: String ->
-                val ot = optionT(NonEmptyList.of(Option.Some(ignored)))
-                val mapped = ot.flatMap { optionT(NonEmptyList.of(Option.None)) }
+                val ot = OptionT(NonEmptyList.of(Option.Some(ignored)))
+                val mapped = ot.flatMap { OptionT(NonEmptyList.of(Option.None)) }
                 val expected = OptionT.none<NonEmptyList.F>()
 
                 mapped == expected
             }
 
             OptionT.none<NonEmptyList.F>()
-                    .flatMap { optionT(NonEmptyList.of(Option.Some(2))) } shouldBe optionT(NonEmptyList.of(Option.None))
+                    .flatMap { OptionT(NonEmptyList.of(Option.Some(2))) } shouldBe OptionT(NonEmptyList.of(Option.None))
         }
 
         "from option should build a correct OptionT" {

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -116,10 +116,6 @@ class OptionTest : UnitSpec() {
             result shouldBe Option(5)
         }
 
-        "kikimangui" {
-            val i: Monad<Option.F> = instance()
-            i.pure(1).ev() shouldBe Option(1)
-        }
     }
 }
 

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -123,27 +123,14 @@ class OptionTest : UnitSpec() {
 
         "kikimangui" {
             val i: Monad<Option.F> = instance()
-            
+            i.pure(1).ev() shouldBe Option(1)
         }
     }
 }
 
 
 //
-open class TypeLiteral<T> {
-    val type: Type
-        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
-}
 
-inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>() {}.type
-
-data class TypeclassInstance<T: Any, F : Any>(val tc: KClass<T>, val fc: KClass<F>)
-
-val GlobalInstances = immutableHashMapOf(
-        (typeLiteral<Monad<Option.F>>()).to(OptionMonad)
-)
-
-inline fun <reified T : Any> instance(): T = GlobalInstances.getValue(typeLiteral<T>()) as T
 
 //inline fun <reified T : Any> instance(): T {
 //    val type = object : TypeReference<T>() {}.type

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -86,12 +86,12 @@ class OptionTest : UnitSpec() {
             forAll { a: Int ->
                 val x = { b: Int -> Option(b * a) }
                 val option = Option(a)
-                option.flatMap(x) == OptionMonad.flatMap(option, x)
+                option.flatMap(x) == Option.flatMap(option, x)
             }
         }
 
         "Option.monad.binding should for comprehend over option" {
-            val result = OptionMonad.binding {
+            val result = Option.binding {
                 val x = !Option(1)
                 val y = Option(1).bind()
                 val z = bind { Option(1) }
@@ -101,14 +101,14 @@ class OptionTest : UnitSpec() {
         }
 
         "Cartesian builder should build products over option" {
-            OptionMonad.map(Option(1), Option("a"), Option(true), { (a, b, c) ->
+            Option.map(Option(1), Option("a"), Option(true), { (a, b, c) ->
                 "$a $b $c"
             }) shouldBe Option("1 a true")
         }
 
         "Cartesian builder works inside for comprehensions" {
-            val result = OptionMonad.binding {
-                val (x, y, z) = !OptionMonad.tupled(Option(1), Option(1), Option(1))
+            val result = Option.binding {
+                val (x, y, z) = !Option.tupled(Option(1), Option(1), Option(1))
                 val a = Option(1).bind()
                 val b = bind { Option(1) }
                 yields(x + y + z + a + b)
@@ -118,16 +118,3 @@ class OptionTest : UnitSpec() {
 
     }
 }
-
-
-//
-
-
-//inline fun <reified T : Any> instance(): T {
-//    val type = object : TypeReference<T>() {}.type
-//    type.typeName
-//    if (type is ParameterizedType)
-//        type.actualTypeArguments.forEach {
-//            println(it.typeName)
-//        }
-//}

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -21,13 +21,7 @@ import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.forAll
 import katz.Option.*
-import kotlinx.collections.immutable.immutableHashMapOf
 import org.junit.runner.RunWith
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.full.*
 
 @RunWith(KTestJUnitRunner::class)
 class OptionTest : UnitSpec() {

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -31,6 +31,7 @@ import kotlin.reflect.full.*
 
 @RunWith(KTestJUnitRunner::class)
 class OptionTest : UnitSpec() {
+
     init {
         "map should modify value" {
             Some(12).map { "flower" } shouldBe Some("flower")

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -21,7 +21,13 @@ import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.forAll
 import katz.Option.*
+import kotlinx.collections.immutable.immutableHashMapOf
 import org.junit.runner.RunWith
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.*
 
 @RunWith(KTestJUnitRunner::class)
 class OptionTest : UnitSpec() {
@@ -114,5 +120,36 @@ class OptionTest : UnitSpec() {
             }
             result shouldBe Option(5)
         }
+
+        "kikimangui" {
+            val i: Monad<Option.F> = instance()
+            
+        }
     }
 }
+
+
+//
+open class TypeLiteral<T> {
+    val type: Type
+        get() = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
+}
+
+inline fun <reified T> typeLiteral(): Type = object : TypeLiteral<T>() {}.type
+
+data class TypeclassInstance<T: Any, F : Any>(val tc: KClass<T>, val fc: KClass<F>)
+
+val GlobalInstances = immutableHashMapOf(
+        (typeLiteral<Monad<Option.F>>()).to(OptionMonad)
+)
+
+inline fun <reified T : Any> instance(): T = GlobalInstances.getValue(typeLiteral<T>()) as T
+
+//inline fun <reified T : Any> instance(): T {
+//    val type = object : TypeReference<T>() {}.type
+//    type.typeName
+//    if (type is ParameterizedType)
+//        type.actualTypeArguments.forEach {
+//            println(it.typeName)
+//        }
+//}


### PR DESCRIPTION
Runtime based default global instances that autoregister on class loads. 
This may be buggy but it's a step forward at getting instances from reified parameters when needed.
All methods provide an alternative where you can pass an instance by param if you wish not to use a global instance.

AS this uses runtime reflection and depends on class static initialization I expect bugs with usage, but won;'t find most cases until we give it a shot.

Runtime reflection for typeclasses. Kotlin,I feel dirty.