### PR TITLE
Fix Jitpack snapshots and CI: disable incremental compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,4 @@ org.gradle.jvmargs=-Xmx2048m
 
 # Kotlin configuration
 kotlin.coroutines=enable
+kotlin.incremental=false


### PR DESCRIPTION
Fixes #71 

Disabling incremental compilation for the project to check how it behaves without it for CI / Jitpack.

CI seems to compile properly (It has not been compiling in my PR #66) for many inference types failing that are also included on this branch code.

Are you ok if we merge this for now to avoid problems? I think this will also help on getting automatic jitpack snapshot deploys working again.