### PR TITLE
Remove license header from all files

### DIFF
--- a/katz/src/main/kotlin/katz/arrow/FunctionK.kt
+++ b/katz/src/main/kotlin/katz/arrow/FunctionK.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface FunctionK<in F, out G> {

--- a/katz/src/main/kotlin/katz/data/Coproduct.kt
+++ b/katz/src/main/kotlin/katz/data/Coproduct.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias CoproductF<F> = HK<Coproduct.F, F>

--- a/katz/src/main/kotlin/katz/data/Either.kt
+++ b/katz/src/main/kotlin/katz/data/Either.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias EitherKind<A, B> = HK2<Either.F, A, B>

--- a/katz/src/main/kotlin/katz/data/Id.kt
+++ b/katz/src/main/kotlin/katz/data/Id.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias IdKind<A> = HK<Id.F, A>

--- a/katz/src/main/kotlin/katz/data/Ior.kt
+++ b/katz/src/main/kotlin/katz/data/Ior.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import katz.Either.Left

--- a/katz/src/main/kotlin/katz/data/NonEmptyList.kt
+++ b/katz/src/main/kotlin/katz/data/NonEmptyList.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias NonEmptyListKind<A> = HK<NonEmptyList.F, A>

--- a/katz/src/main/kotlin/katz/data/Option.kt
+++ b/katz/src/main/kotlin/katz/data/Option.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias OptionKind<A> = HK<Option.F, A>

--- a/katz/src/main/kotlin/katz/data/OptionT.kt
+++ b/katz/src/main/kotlin/katz/data/OptionT.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package katz
 
 typealias OptionTKind<F, A> = HK2<OptionT.F, F, A>

--- a/katz/src/main/kotlin/katz/data/Try.kt
+++ b/katz/src/main/kotlin/katz/data/Try.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias TryKind<A> = HK<Try.F, A>

--- a/katz/src/main/kotlin/katz/data/Validated.kt
+++ b/katz/src/main/kotlin/katz/data/Validated.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 typealias ValidatedKind<E, A> = HK2<Validated.F, E, A>

--- a/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
+++ b/katz/src/main/kotlin/katz/instances/CoproductComonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 class CoproductComonad<F, G> : Comonad<CoproductFG<F, G>> {

--- a/katz/src/main/kotlin/katz/instances/EitherMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/EitherMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 class EitherMonad<L> : Monad<EitherF<L>> {

--- a/katz/src/main/kotlin/katz/instances/IdMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IdMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface IdMonad : Monad<Id.F> {

--- a/katz/src/main/kotlin/katz/instances/IorMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/IorMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 class IorMonad<L>(val SL: Semigroup<L>) : Monad<HK<Ior.F, L>> {

--- a/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/NonEmptyListMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface NonEmptyListMonad : Monad<NonEmptyList.F> {

--- a/katz/src/main/kotlin/katz/instances/OptionMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface OptionMonad : Monad<Option.F> {

--- a/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
+++ b/katz/src/main/kotlin/katz/instances/OptionTMonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 class OptionTMonad<F>(val MF : Monad<F>) : Monad<OptionTF<F>> {

--- a/katz/src/main/kotlin/katz/instances/TryMonadError.kt
+++ b/katz/src/main/kotlin/katz/instances/TryMonadError.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface TryMonadError : MonadError<Try.F, Throwable> {

--- a/katz/src/main/kotlin/katz/instances/ValidatedApplicativeError.kt
+++ b/katz/src/main/kotlin/katz/instances/ValidatedApplicativeError.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 class ValidatedApplicativeError<E>(val SE: Semigroup<E>) : ApplicativeError<ValidatedF<E>, E> {

--- a/katz/src/main/kotlin/katz/predef.kt
+++ b/katz/src/main/kotlin/katz/predef.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 object IntMonoid : Monoid<Int>, GlobalInstance<Monoid<Int>>() {

--- a/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Applicative.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 @file:Suppress("UNUSED_PARAMETER")
 
 package katz

--- a/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/ApplicativeError.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface ApplicativeError<F, E> : Applicative<F>, Typeclass {

--- a/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Comonad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 /**

--- a/katz/src/main/kotlin/katz/typeclasses/ContinuationUtils.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/ContinuationUtils.kt
@@ -1,10 +1,3 @@
-/*
- * Copyright Sergey Igushkin https://github.com/h0tk3y
- *
- * This file adapted and modified to fit this project originally comes from
- * https://github.com/h0tk3y/kotlin-monads/blob/master/src/main/kotlin/com/github/h0tk3y/kotlinMonads/ContinuationUtils.kt
- */
-
 package katz
 
 import kotlin.coroutines.experimental.Continuation

--- a/katz/src/main/kotlin/katz/typeclasses/Functor.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Functor.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface Functor<F> : Typeclass {

--- a/katz/src/main/kotlin/katz/typeclasses/HigherKinds.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/HigherKinds.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface HK<out F, out A>

--- a/katz/src/main/kotlin/katz/typeclasses/Inject.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Inject.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 /**

--- a/katz/src/main/kotlin/katz/typeclasses/Monad.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Monad.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import java.io.Serializable

--- a/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/MonadError.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import java.io.Serializable

--- a/katz/src/main/kotlin/katz/typeclasses/Monoid.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Monoid.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface Monoid<A> : Semigroup<A> {

--- a/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Semigroup.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 interface Semigroup<A> : Typeclass {

--- a/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
+++ b/katz/src/main/kotlin/katz/typeclasses/Typeclass.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import java.lang.reflect.ParameterizedType

--- a/katz/src/test/kotlin/instances/GlobalInstancesTest.kt
+++ b/katz/src/test/kotlin/instances/GlobalInstancesTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/ReaderTest.kt
+++ b/katz/src/test/kotlin/katz/ReaderTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Kats Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/UnitSpec.kt
+++ b/katz/src/test/kotlin/katz/UnitSpec.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.specs.StringSpec

--- a/katz/src/test/kotlin/katz/data/EitherTest.kt
+++ b/katz/src/test/kotlin/katz/data/EitherTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/data/NonEmptyListTest.kt
+++ b/katz/src/test/kotlin/katz/data/NonEmptyListTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/data/OptionTTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTTest.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/data/OptionTest.kt
+++ b/katz/src/test/kotlin/katz/data/OptionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/data/TryTest.kt
+++ b/katz/src/test/kotlin/katz/data/TryTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import io.kotlintest.KTestJUnitRunner

--- a/katz/src/test/kotlin/katz/data/ValidatedTest.kt
+++ b/katz/src/test/kotlin/katz/data/ValidatedTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Katz Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package katz
 
 import com.sun.net.httpserver.Authenticator


### PR DESCRIPTION
PR #66 has ported licenses to `LICENSE.md` file so we no longer need to include it on all the library files.