### PR TITLE
Fix position of default argument for monad implicit to align with Kotlin expectation

### DIFF
--- a/katz/src/main/kotlin/katz/data/Kleisli.kt
+++ b/katz/src/main/kotlin/katz/data/Kleisli.kt
@@ -23,9 +23,9 @@ class Kleisli<F, D, A>(val MF: Monad<F>, val run: (D) -> HK<F, A>) {
 
     companion object {
 
-        inline operator fun <reified F, D, A> invoke(MF: Monad<F> = monad<F>(), noinline run: (D) -> HK<F, A>): Kleisli<F, D, A> = Kleisli(MF, run)
+        inline operator fun <reified F, D, A> invoke(noinline run: (D) -> HK<F, A>, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> = Kleisli(MF, run)
 
-        inline fun <reified F, D, A> pure(MF: Monad<F> = monad<F>(), x: A): Kleisli<F, D, A> = Kleisli(MF, { _ -> MF.pure(x) })
+        inline fun <reified F, D, A> pure(x: A, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> = Kleisli(MF, { _ -> MF.pure(x) })
 
         inline fun <reified F, D> ask(MF: Monad<F> = monad<F>()): Kleisli<F, D, D> = Kleisli(MF, { MF.pure(it) })
     }

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -10,10 +10,10 @@ fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A = this.run(d).value()
 
 object Reader {
 
-    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> = Kleisli(Id, run.andThen { Id(it) })
+    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> = Kleisli(run.andThen { Id(it) })
 
-    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> = Kleisli.pure<Id.F, D, A>(Id, x)
+    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> = Kleisli.pure<Id.F, D, A>(x)
 
-    fun <D> ask(): ReaderT<Id.F, D, D> = Kleisli.ask<Id.F, D>(Id)
+    fun <D> ask(): ReaderT<Id.F, D, D> = Kleisli.ask<Id.F, D>()
 
 }


### PR DESCRIPTION
Skipping default parameters only works for the last parameter position. Kleisli didn't follow this convention.

<img width="964" alt="screen shot 2017-04-23 at 11 00 13 pm" src="https://cloud.githubusercontent.com/assets/514871/25317860/644a9edc-2879-11e7-9a6b-b38ddc661ca7.png">
