### PR TITLE
Add Yoneda and CoYoneda, along with their Functor instances

### DIFF
--- a/katz/src/main/kotlin/katz/free/CoYoneda.kt
+++ b/katz/src/main/kotlin/katz/free/CoYoneda.kt
@@ -1,0 +1,25 @@
+package katz
+
+typealias CoYonedaKind<U, P, A> = HK3<CoYoneda.F, U, P, A>
+
+typealias CoYonedaF<U, P> = HK2<CoYoneda.F, U, P>
+
+data class CoYoneda<FU, P, A>(val function: (P) -> A, val pivot: HK<FU, P>) : CoYonedaKind<FU, P, A> {
+    class F private constructor()
+
+    fun lower(FF: Functor<FU>): HK<FU, A> = FF.map(pivot, function)
+
+    fun <B> map(f: (A) -> B): CoYoneda<FU, P, B> = CoYoneda({ f(function(it)) }, pivot)
+
+    fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> = object: Yoneda<FU, A> {
+        override fun <B> apply(f: (A) -> B): HK<FU, B> = map(f).lower(FF)
+    }
+
+    companion object {
+        inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> =
+                CoYoneda(f, fa)
+    }
+
+}
+
+fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> = this as CoYoneda<U, A, B>

--- a/katz/src/main/kotlin/katz/free/CoYoneda.kt
+++ b/katz/src/main/kotlin/katz/free/CoYoneda.kt
@@ -11,7 +11,7 @@ data class CoYoneda<FU, P, A>(val function: (P) -> A, val pivot: HK<FU, P>) : Co
 
     fun <B> map(f: (A) -> B): CoYoneda<FU, P, B> = CoYoneda({ f(function(it)) }, pivot)
 
-    fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> = object: Yoneda<FU, A> {
+    fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> = object : Yoneda<FU, A> {
         override fun <B> apply(f: (A) -> B): HK<FU, B> = map(f).lower(FF)
     }
 

--- a/katz/src/main/kotlin/katz/free/Free.kt
+++ b/katz/src/main/kotlin/katz/free/Free.kt
@@ -43,7 +43,7 @@ tailrec fun <S, A> Free<S, A>.step(): Free<S, A> =
     }
 
 @Suppress("UNCHECKED_CAST")
-fun <M, S, A> Free<S, A>.foldMap(MM: Monad<M>, f: FunctionK<S, M>): HK<M, A> =
+fun <M, S, A> Free<S, A>.foldMap(f: FunctionK<S, M>, MM: Monad<M>): HK<M, A> =
         MM.tailRecM(this) {
             val x = it.step()
             when (x) {
@@ -52,7 +52,7 @@ fun <M, S, A> Free<S, A>.foldMap(MM: Monad<M>, f: FunctionK<S, M>): HK<M, A> =
                 is Free.FlatMapped<S, A, *> -> {
                     val g = (x.f as (A) -> Free<S, A>)
                     val c = x.c as Free<S, A>
-                    MM.map(c.foldMap(MM, f), { cc -> Either.Left(g(cc)) })
+                    MM.map(c.foldMap(f, MM), { cc -> Either.Left(g(cc)) })
                 }
             }
         }

--- a/katz/src/main/kotlin/katz/free/Yoneda.kt
+++ b/katz/src/main/kotlin/katz/free/Yoneda.kt
@@ -4,8 +4,7 @@ typealias YonedaKind<U, A> = HK2<Yoneda.F, U, A>
 
 typealias YonedaF<U> = HK<Yoneda.F, U>
 
-// FIXME using YonedaKind throws a compiler error, but not the expanded form
-interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
+interface Yoneda<FU, A> : YonedaKind<FU, A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/free/Yoneda.kt
+++ b/katz/src/main/kotlin/katz/free/Yoneda.kt
@@ -4,7 +4,8 @@ typealias YonedaKind<U, A> = HK2<Yoneda.F, U, A>
 
 typealias YonedaF<U> = HK<Yoneda.F, U>
 
-interface Yoneda<FU, A> : YonedaKind<FU, A> {
+// FIXME using YonedaKind throws a compiler error, but not the expanded form
+interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
 
     class F private constructor()
 

--- a/katz/src/main/kotlin/katz/free/Yoneda.kt
+++ b/katz/src/main/kotlin/katz/free/Yoneda.kt
@@ -11,7 +11,7 @@ interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
 
     fun <B> apply(f: (A) -> B): HK<FU, B>
 
-    fun lower(): HK<FU, A> = apply{ a -> a }
+    fun lower(): HK<FU, A> = apply { a -> a }
 
     fun <B> map(ff: (A) -> B, FF: Functor<FU>): Yoneda<FU, B> = object : Yoneda<FU, B> {
         override fun <C> apply(f: (B) -> C): HK<FU, C> = this@Yoneda.apply({ f(ff(it)) })
@@ -20,7 +20,7 @@ interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
     fun toCoYoneda(): CoYoneda<FU, A, A> = CoYoneda({ it }, lower())
 
     companion object {
-        inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = functor()): Yoneda<U, A> = object: Yoneda<U, A> {
+        inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = functor()): Yoneda<U, A> = object : Yoneda<U, A> {
             override fun <B> apply(f: (A) -> B): HK<U, B> = FF.map(fa, f)
         }
     }

--- a/katz/src/main/kotlin/katz/free/Yoneda.kt
+++ b/katz/src/main/kotlin/katz/free/Yoneda.kt
@@ -1,0 +1,29 @@
+package katz
+
+typealias YonedaKind<U, A> = HK2<Yoneda.F, U, A>
+
+typealias YonedaF<U> = HK<Yoneda.F, U>
+
+// FIXME using YonedaKind throws a compiler error, but not the expanded form
+interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
+
+    class F private constructor()
+
+    fun <B> apply(f: (A) -> B): HK<FU, B>
+
+    fun lower(): HK<FU, A> = apply{ a -> a }
+
+    fun <B> map(ff: (A) -> B, FF: Functor<FU>): Yoneda<FU, B> = object : Yoneda<FU, B> {
+        override fun <C> apply(f: (B) -> C): HK<FU, C> = this@Yoneda.apply({ f(ff(it)) })
+    }
+
+    fun toCoYoneda(): CoYoneda<FU, A, A> = CoYoneda({ it }, lower())
+
+    companion object {
+        inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = functor()): Yoneda<U, A> = object: Yoneda<U, A> {
+            override fun <B> apply(f: (A) -> B): HK<U, B> = FF.map(fa, f)
+        }
+    }
+}
+
+fun <U, A> YonedaKind<U, A>.ev(): Yoneda<U, A> = this as Yoneda<U, A>

--- a/katz/src/main/kotlin/katz/instances/CoYonedaFunctor.kt
+++ b/katz/src/main/kotlin/katz/instances/CoYonedaFunctor.kt
@@ -1,0 +1,6 @@
+package katz
+
+class CoYonedaFunctor<U, P> : Functor<CoYonedaF<U, P>> {
+    override fun <A, B> map(fa: HK<CoYonedaF<U, P>, A>, f: (A) -> B): HK<CoYonedaF<U, P>, B> =
+            fa.ev().map(f)
+}

--- a/katz/src/main/kotlin/katz/instances/YonedaFunctor.kt
+++ b/katz/src/main/kotlin/katz/instances/YonedaFunctor.kt
@@ -1,0 +1,6 @@
+package katz
+
+class YonedaFunctor<U>(val FM: Functor<U>) : Functor<YonedaF<U>> {
+    override fun <A, B> map(fa: HK<YonedaF<U>, A>, f: (A) -> B): HK<YonedaF<U>, B> =
+            fa.ev().map(f, FM)
+}

--- a/katz/src/test/kotlin/katz/free/CoYonedaTest.kt
+++ b/katz/src/test/kotlin/katz/free/CoYonedaTest.kt
@@ -1,0 +1,41 @@
+package katz
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.forAll
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class CoYonedaTest : UnitSpec() {
+
+    init {
+        "map should modify the content of any HK1" {
+            forAll { x: Int ->
+                val op = CoYoneda.apply(Id(x), { _ -> "" })
+                val mapped = op.map { _ -> true }.lower(functor<Id.F>())
+                val expected = Id(true)
+
+                expected == mapped
+            }
+        }
+
+        "instance map should be consistent with CoYonedaFunctor#map" {
+            forAll { x: Int ->
+                val op = CoYoneda.apply(Id(x), { _ -> "" })
+                val mapped = op.map { _ -> true }.lower(functor<Id.F>())
+                val expected = CoYonedaFunctor<Id.F, Int>().map(op, {_ -> true}).ev().lower(functor<Id.F>())
+
+                expected == mapped
+            }
+        }
+
+        "toYoneda should convert to an equivalent Yoneda" {
+            forAll { x: Int ->
+                val op = CoYoneda.apply(Id(x), Int::toString)
+                val toYoneda = op.toYoneda(functor<Id.F>()).lower().ev()
+                val expected = Yoneda.apply(Id(x.toString())).lower().ev()
+
+                expected == toYoneda
+            }
+        }
+    }
+}

--- a/katz/src/test/kotlin/katz/free/FreeTest.kt
+++ b/katz/src/test/kotlin/katz/free/FreeTest.kt
@@ -4,7 +4,7 @@ import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
 import org.junit.runner.RunWith
 
-sealed class Ops<A> : HK<Ops.F, A> {
+sealed class Ops<out A> : HK<Ops.F, A> {
 
     class F private constructor()
 
@@ -72,15 +72,15 @@ class FreeTest : UnitSpec() {
     init {
 
         "Can interpret an ADT as Free operations" {
-            program.foldMap(Option, optionInterpreter).ev() shouldBe Option.Some(-30)
-            program.foldMap(Id, idInterpreter).ev() shouldBe Id(-30)
-            program.foldMap(NonEmptyList, nonEmptyListInterpter).ev() shouldBe NonEmptyList.of(-30)
+            program.foldMap(optionInterpreter, Option).ev() shouldBe Option.Some(-30)
+            program.foldMap(idInterpreter, Id).ev() shouldBe Id(-30)
+            program.foldMap(nonEmptyListInterpter, NonEmptyList).ev() shouldBe NonEmptyList.of(-30)
         }
 
         "foldMap is stack safe" {
             val n = 50000
             val hugeProg = stackSafeTestProgram(0, n)
-            hugeProg.foldMap(Id, idInterpreter).value() shouldBe n
+            hugeProg.foldMap(idInterpreter, Id).value() shouldBe n
         }
 
     }

--- a/katz/src/test/kotlin/katz/free/YonedaTest.kt
+++ b/katz/src/test/kotlin/katz/free/YonedaTest.kt
@@ -1,0 +1,41 @@
+package katz
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.forAll
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class YonedaTest : UnitSpec() {
+
+    init {
+        "map should modify the content of any HK1" {
+            forAll { x: Int ->
+                val op = Yoneda.apply(Id(x))
+                val mapped = op.map({ _ -> true }, functor<Id.F>()).lower()
+                val expected = Id(true)
+
+                expected == mapped
+            }
+        }
+
+        "instance map should be consistent with YonedaFunctor#map" {
+            forAll { x: Int ->
+                val op = Yoneda.apply(Id(x))
+                val mapped = op.map({ _ -> true }, functor()).lower()
+                val expected = YonedaFunctor<Id.F>(functor()).map(op, { _ -> true}).ev().lower()
+
+                expected == mapped
+            }
+        }
+
+        "toCoYoneda should convert to an equivalent CoYoneda" {
+            forAll { x: Int ->
+                val op = Yoneda.apply(Id(x.toString()))
+                val toYoneda = op.toCoYoneda().lower(functor<Id.F>()).ev()
+                val expected = CoYoneda.apply(Id(x), Int::toString).lower(functor<Id.F>()).ev()
+
+                expected == toYoneda
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add two central pieces to the Free machinery: Yoneda and CoYoneda. They include a minimal implementation, along with a Functor instance. I've also written a minimal test suite for each.

For consistency purposes I've swapped the parameter order in the Free class.

Closes #80 